### PR TITLE
Limit concurrency

### DIFF
--- a/generate/index.js
+++ b/generate/index.js
@@ -2,6 +2,8 @@
 import Rx from 'rxjs/Rx'
 import {random as randomEmoji} from 'random-emoji'
 
+const maxConcurrent = 10
+
 Rx.Observable
   .from([
     './home',
@@ -13,8 +15,7 @@ Rx.Observable
     './workshops',
   ])
   .map(modPath => require(modPath).default) // eslint-disable-line
-  // .merge(2) // this doesn't appear to be limiting the concurrent requests
-  .flatMap(fn => fn())
+  .mergeMap(fn => Rx.Observable.of(fn()), undefined, maxConcurrent)
   .subscribe({
     error: err => {
       console.error('something wrong happened:', err)


### PR DESCRIPTION
Hey, @kentcdodds. I bookmarked this to look at when I finally got around to losing my RxJs virginity. It's been very helpful. From what I can tell, the way to limit concurrency seems to be with [`mergeMap()`](http://reactivex.io/rxjs/class/es6/Observable.js%7EObservable.html#instance-method-mergeMap). I have not tested this change, but mirrored what I have done in my own code. Hope this helps...

Cheers,
Erik