### PR TITLE
Update CSS Grid properties to fix layout in small viewport

### DIFF
--- a/src/pages/home/index.js
+++ b/src/pages/home/index.js
@@ -25,7 +25,7 @@ function Home() {
           style={{
             marginLeft: 'auto',
             marginRight: 'auto',
-            width: 800,
+            maxWidth: 800,
             display: 'flex',
             flexDirection: 'column',
             justifyContent: 'center',
@@ -49,9 +49,10 @@ function Home() {
               marginLeft: 'auto',
               marginRight: 'auto',
               display: 'grid',
-              gridTemplateColumns: 'repeat(5, 1fr)',
+              gridTemplateColumns: 'repeat(auto-fill, minmax(140px, 1fr))',
               gridColumnGap: '10px',
               gridRowGap: '30px',
+              justifyItems: 'center',
             }}
           >
             {[


### PR DESCRIPTION
On small viewport like iPhones and other phones, the user has to scroll horizontally to view all the content on the page. This pull request fixes that by adjusting the layout as the viewport is made smaller.