### PR TITLE
fix: correct about page typo

### DIFF
--- a/src/pages/about.mdx
+++ b/src/pages/about.mdx
@@ -27,8 +27,8 @@ Web Development on various platforms including:
 [YouTube](https://kcd.im/youtube), [Twitter](https://kcd.im/twitter), and my own
 sites like [TestingJavaScript.com](https://testingjavascript.com) 🏆
 
-While in school at BYU, I met my wife Brooke. We live in Utah with with our four
-kids and dog 👧👦👦👦🐶.
+While in school at BYU, I met my wife Brooke. We live in Utah with our four kids
+and dog 👧👦👦👦🐶.
 
 > P.S. Here are a few pages on this site that aren't included in the normal site
 > naviagation, but might interest you:


### PR DESCRIPTION
This PR corrects a typo (double "with") found on the About page