### PR TITLE
fix: youtube iframe's style on mobile

### DIFF
--- a/plugins/remark-embedder/get-youtube-html.js
+++ b/plugins/remark-embedder/get-youtube-html.js
@@ -25,7 +25,7 @@ function getUrl(string) {
 
 function getYouTubeHTML(string) {
   const iframeSrc = getYouTubeIFrameSrc(string)
-  return `<iframe width="560" height="315" src="${iframeSrc}" frameBorder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowFullScreen></iframe>`
+  return `<iframe width="100%" height="315" src="${iframeSrc}" frameBorder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowFullScreen></iframe>`
 }
 
 function getYouTubeIFrameSrc(string) {


### PR DESCRIPTION
Fix youtube's widget overflowing on mobile

**Mobile**:
Before:
![image](https://user-images.githubusercontent.com/9272629/53298804-409c8d80-3833-11e9-8f91-5a2d2a8f01cd.png)

After:
![image](https://user-images.githubusercontent.com/9272629/53298825-6aee4b00-3833-11e9-8127-548065a6d962.png)

**Desktop**:
Before:
![image](https://user-images.githubusercontent.com/9272629/53298844-9d984380-3833-11e9-9390-8eb519d5be8c.png)
After:
![image](https://user-images.githubusercontent.com/9272629/53298834-8eb19100-3833-11e9-9d3b-bd9f347ca3b1.png)
