### PR TITLE
Add GraphQL custom fragments for Gatsby Image

### DIFF
--- a/src/lib/fragments.js
+++ b/src/lib/fragments.js
@@ -1,0 +1,18 @@
+import {graphql} from 'gatsby'
+
+export const bannerImage = graphql`
+  fragment bannerImage640 on File {
+    childImageSharp {
+      fluid(maxWidth: 640, traceSVG: {color: "#573ede"}) {
+        ...GatsbyImageSharpFluid_withWebp_tracedSVG
+      }
+    }
+  }
+  fragment bannerImage720 on File {
+    childImageSharp {
+      fluid(maxWidth: 720, traceSVG: {color: "#573ede"}, quality: 75) {
+        ...GatsbyImageSharpFluid_withWebp_tracedSVG
+      }
+    }
+  }
+`

--- a/src/templates/blog.js
+++ b/src/templates/blog.js
@@ -37,11 +37,7 @@ export default function CodingBlogWithData(props) {
                   title
                   date(formatString: "MMMM DD, YYYY")
                   banner {
-                    childImageSharp {
-                      fluid(maxWidth: 600) {
-                        ...GatsbyImageSharpFluid_withWebp_tracedSVG
-                      }
-                    }
+                    ...bannerImage640
                   }
                   slug
                   keywords

--- a/src/templates/post.js
+++ b/src/templates/post.js
@@ -136,11 +136,7 @@ export const pageQuery = graphql`
         date(formatString: "MMMM DD, YYYY")
         author
         banner {
-          childImageSharp {
-            fluid(maxWidth: 900) {
-              ...GatsbyImageSharpFluid_withWebp_tracedSVG
-            }
-          }
+          ...bannerImage720
         }
         bannerCredit
         slug

--- a/src/templates/writing-blog.js
+++ b/src/templates/writing-blog.js
@@ -38,11 +38,7 @@ export default function WritingBlogWithData(props) {
                   title
                   date(formatString: "MMMM DD, YYYY")
                   banner {
-                    childImageSharp {
-                      fluid(maxWidth: 600) {
-                        ...GatsbyImageSharpFluid_withWebp_tracedSVG
-                      }
-                    }
+                    ...bannerImage640
                   }
                   slug
                   keywords


### PR DESCRIPTION
As subject I added some GraphQL fragments to customize the traced SVG effect color and for improve the reusability for the Gatsby Image plugin.