### PR TITLE
Fix HMR slowness

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "gatsby": "2.1.9",
     "gatsby-image": "^2.0.31",
     "gatsby-link": "^2.0.14",
-    "gatsby-mdx": "^0.4.2",
+    "gatsby-mdx": "^0.4.4",
     "gatsby-plugin-catch-links": "^2.0.12",
     "gatsby-plugin-emotion": "^4.0.4",
     "gatsby-plugin-feed": "^2.0.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6313,10 +6313,10 @@ gatsby-link@^2.0.11, gatsby-link@^2.0.14:
     "@types/reach__router" "^1.0.0"
     prop-types "^15.6.1"
 
-gatsby-mdx@^0.4.2:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/gatsby-mdx/-/gatsby-mdx-0.4.2.tgz#81a44a39417911f752ebf1847ac0aec9bcb2497b"
-  integrity sha512-QML0XE/fKjTuKgoi0y2H+c5GBWcAKluuYF69xEttPHmb1ptqIwJ0a6o7PsK1jU8KuhE+gbklyHlX5iWB1kZKpA==
+gatsby-mdx@^0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/gatsby-mdx/-/gatsby-mdx-0.4.4.tgz#1297101f6018c6cf03319c6e0acd508a01478fa6"
+  integrity sha512-OOJqN4nQjo0dmfyWGk8R3nOdc2duGYydbxDdjCfFqRLQCxkVvRvAWNqxZG7LzAqdwqRUYW7pRWm9RNrwwttsmw==
   dependencies:
     "@babel/plugin-proposal-object-rest-spread" "^7.0.0"
     debug "^4.0.1"


### PR DESCRIPTION
gatsby-mdx [fixed a performance issue in
0.4.4](https://github.com/ChristopherBiscardi/gatsby-mdx/commit/fb8d6d6e87bfaced2176b4ff639a91bc6ab0e9c1). Upgrade
to the version with the fix. It brings the HMR time down from 20+
seconds to 3-4 seconds.