### PR TITLE
fix: disable density check for images

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -68,7 +68,6 @@ module.exports = {
             options: {
               backgroundColor: '#fafafa',
               maxWidth: 1035,
-              sizeByPixelDensity: true,
             },
           },
           {resolve: require.resolve('./plugins/remark-embedder')},


### PR DESCRIPTION
Turns out the density shouldn’t be supported for JPG/PNG images, so we're going to fix that, but for now you can safely disable this setting and it _should_ eliminate the tiny image problem.