### PR TITLE
Fix line highlight for overflowing code snippets

### DIFF
--- a/src/components/mdx/code.js
+++ b/src/components/mdx/code.js
@@ -5,6 +5,16 @@ import Highlight, {defaultProps} from 'prism-react-renderer'
 
 const RE = /{([\d,-]+)}/
 
+const wrapperStyles = css`
+  overflow: auto;
+`
+
+const preStyles = css`
+  float: left;
+  min-width: 100%;
+  overflow: initial;
+`
+
 function calculateLinesToHighlight(meta) {
   if (RE.test(meta)) {
     const lineNumbers = RE.exec(meta)[1]
@@ -32,32 +42,34 @@ function Code({codeString, language, metastring}) {
       theme={theme}
     >
       {({className, style, tokens, getLineProps, getTokenProps}) => (
-        <pre className={className} style={style}>
-          {tokens.map((line, i) => (
-            <div
-              key={i}
-              {...getLineProps({
-                line,
-                key: i,
-                className: shouldHighlightLine(i) ? 'highlight-line' : '',
-              })}
-            >
-              <span
-                css={css`
-                  display: inline-block;
-                  width: 2em;
-                  user-select: none;
-                  opacity: 0.3;
-                `}
+        <div css={wrapperStyles}>
+          <pre className={className} style={style} css={preStyles}>
+            {tokens.map((line, i) => (
+              <div
+                key={i}
+                {...getLineProps({
+                  line,
+                  key: i,
+                  className: shouldHighlightLine(i) ? 'highlight-line' : '',
+                })}
               >
-                {i + 1}
-              </span>
-              {line.map((token, key) => (
-                <span key={key} {...getTokenProps({token, key})} />
-              ))}
-            </div>
-          ))}
-        </pre>
+                <span
+                  css={css`
+                    display: inline-block;
+                    width: 2em;
+                    user-select: none;
+                    opacity: 0.3;
+                  `}
+                >
+                  {i + 1}
+                </span>
+                {line.map((token, key) => (
+                  <span key={key} {...getTokenProps({token, key})} />
+                ))}
+              </div>
+            ))}
+          </pre>
+        </div>
       )}
     </Highlight>
   )


### PR DESCRIPTION
- How [gatsby-remark-prismjs](https://www.gatsbyjs.org/packages/gatsby-remark-prismjs) structures the code

![Screen Shot 2019-03-26 at 9 23 56 PM](https://user-images.githubusercontent.com/4951004/55027307-a1271200-500d-11e9-8f59-da1de60ac382.png)

- A preview

![Mar-26-2019 21-24-39](https://user-images.githubusercontent.com/4951004/55027350-bf8d0d80-500d-11e9-9133-c9ed2d3adc2b.gif)
