### PR TITLE
Updated links for downshift release article.

### DIFF
--- a/content/blog/how-to-give-rendering-control-to-users-with-prop-getters/index.md
+++ b/content/blog/how-to-give-rendering-control-to-users-with-prop-getters/index.md
@@ -23,13 +23,13 @@ bannerCredit:
 > [Use Prop Getters with Render Props](https://egghead.io/lessons/react-use-prop-getters-with-render-props)
 
 Since I
-[released downshift 🏎](https://medium.com/@kentcdodds/introducing-downshift-for-react-b1de3fca0817)
+[released downshift 🏎](https://kentcdodds.com/blog/introducing-downshift-for-react)
 a few weeks ago. Of all things, I think the most common question I've gotten has
 been about the "prop getters." As far as I know,
 [downshift](https://github.com/paypal/downshift) is the first library to
 implement this pattern, so I thought I'd explain why it's useful and how to
 implement it. If you're unfamiliar with downshift, please read
-[the intro post](https://medium.com/@kentcdodds/introducing-downshift-for-react-b1de3fca0817)
+[the intro post](https://kentcdodds.com/blog/introducing-downshift-for-react)
 before you continue. Don't worry, I'll wait...
 
 ![dog wagging the tail while waiting](./images/0.gif)


### PR DESCRIPTION
There were a couple of links pointing to medium, but the articles do not exist in medium anymore, so just added the correct links.