### PR TITLE
useMemo isn't required for values returned by useState

### DIFF
--- a/content/blog/application-state-management-with-react/index.md
+++ b/content/blog/application-state-management-with-react/index.md
@@ -189,8 +189,7 @@ function useCount() {
 
 function CountProvider(props) {
   const [count, setCount] = React.useState(0)
-  const value = React.useMemo(() => [count, setCount], [count])
-  return <CountContext.Provider value={value} {...props} />
+  return <CountContext.Provider value={[count, setCount]} {...props} />
 }
 
 // src/index.js


### PR DESCRIPTION
Hi @kentcdodds , thanks for the great blog article !

I don't think `useMemo` is required in this example because the setter returned by `useState` should always the same reference.
Here's a demo that shows this: https://codesandbox.io/s/3vnx7q42l1