### PR TITLE
Fix links

### DIFF
--- a/content/blog/2018-in-review/index.md
+++ b/content/blog/2018-in-review/index.md
@@ -59,7 +59,7 @@ for making
 I'm super proud of what we've accomplished here. The
 [react-testing-library all contributors table](https://github.com/testing-library/react-testing-library/blob/master/README.md#contributors)
 lists 63 awesome people, and the
-[dom-testing-library all contributors table](https://github.com/kentcdodds/dom-testing-library/blob/master/README.md#contributors)
+[dom-testing-library all contributors table](https://github.com/testing-library/dom-testing-library/blob/master/README.md#contributors)
 lists 46 (many repeats, but not all). These people are amazing and I really
 appreciate what they've done. I don't want to leave anyone out, but I would like
 to give a special shout out to these folks: [Giorgio](https://twitter.com/Gpx),

--- a/content/blog/2018-in-review/index.md
+++ b/content/blog/2018-in-review/index.md
@@ -226,7 +226,7 @@ realm of Open Source that I'd like to mention. Here are a few numbers:
   WOW. 🤯
 - I [deprecated glamorous](https://github.com/paypal/glamorous/issues/419) in
   favor of [emotion.sh](https://emotion.sh)
-- Published v2 and v3 of [downshift](https://github.com/paypal/downshift).
+- Published v2 and v3 of [downshift](https://github.com/downshift-js/downshift).
 - There are now
   [over 2k `.all-contributorsrc` files on GitHub](https://github.com/search?q=.all-contributorsrc+in%3Apath&type=Code&utf8=✓)
   😱

--- a/content/blog/2018-in-review/index.md
+++ b/content/blog/2018-in-review/index.md
@@ -25,10 +25,10 @@ mostly a secret and surprise 😃).
 > Note: I don't want to bother with trying to sort these in any particular
 > order, so... they're not in any particular order...
 
-## [react-testing-library](https://github.com/kentcdodds/react-testing-library)
+## [react-testing-library](https://github.com/testing-library/react-testing-library)
 
 This year I
-[created](https://github.com/kentcdodds/react-testing-library/commit/4f16c6e6b356fae1ad92f59eebeb1a8000f60714)
+[created](https://github.com/testing-library/react-testing-library/commit/4f16c6e6b356fae1ad92f59eebeb1a8000f60714)
 and
 [introduced react-testing-library](https://blog.kentcdodds.com/introducing-the-react-testing-library-e3a274307e65).
 It has [grown a lot](https://www.npmtrends.com/react-testing-library) since
@@ -57,7 +57,7 @@ for making
 [react-native-testing-library](https://github.com/callstack/react-native-testing-library).
 
 I'm super proud of what we've accomplished here. The
-[react-testing-library all contributors table](https://github.com/kentcdodds/react-testing-library/blob/master/README.md#contributors)
+[react-testing-library all contributors table](https://github.com/testing-library/react-testing-library/blob/master/README.md#contributors)
 lists 63 awesome people, and the
 [dom-testing-library all contributors table](https://github.com/kentcdodds/dom-testing-library/blob/master/README.md#contributors)
 lists 46 (many repeats, but not all). These people are amazing and I really

--- a/content/blog/2018-in-review/index.md
+++ b/content/blog/2018-in-review/index.md
@@ -30,7 +30,7 @@ mostly a secret and surprise 😃).
 This year I
 [created](https://github.com/testing-library/react-testing-library/commit/4f16c6e6b356fae1ad92f59eebeb1a8000f60714)
 and
-[introduced react-testing-library](https://blog.kentcdodds.com/introducing-the-react-testing-library-e3a274307e65).
+[introduced react-testing-library](/blog/introducing-the-react-testing-library).
 It has [grown a lot](https://www.npmtrends.com/react-testing-library) since
 then. [The spectrum community](https://spectrum.chat/testing-library) has
 [over 300 members now](https://twitter.com/kentcdodds/status/1079523389553790976).
@@ -135,7 +135,7 @@ This was a HUGE effort by me and the good folks at
 courses + 9 podcast episodes. It was a TON of work and people LOVE it. So I'm
 really happy with this.
 
-## [paypal-scripts](https://blog.kentcdodds.com/automation-without-config-412ab5e47229)
+## [paypal-scripts](/blog/tools-without-config)
 
 I started this project in August of 2017, but most of the work was done in 2018.
 It's basically a single tool that consolidates a bunch of other tools common to
@@ -289,8 +289,8 @@ Here are some other interesting facts/accomplishments from 2018:
   DAYS worth of time of Brandon Sanderson fantasy novels in 2018. I listen at
   2.9x speed, so it amounts to ~10 days of time, but still. I've filled my ears
   with his words this year!
-- I posted 62 new blog posts on [my blog](https://blog.kentcdodds.com) on
-  subjects around JavaScript, Testing, React, as well as career advice.
+- I posted 62 new blog posts on [my blog](/blog) on subjects around JavaScript,
+  Testing, React, as well as career advice.
 - In 2018, I spent most of my course time on testingjavascript.com, but I did
   manage to make a complete update to
   [Advanced React Component Patterns](https://kcd.im/advanced-react) and make

--- a/content/blog/advanced-react-component-patterns/index.md
+++ b/content/blog/advanced-react-component-patterns/index.md
@@ -116,8 +116,8 @@ necessary to allow the user of the component to render what they need for their
 use case.
 
 My personal favorite implementation of this pattern (and some of the following
-patterns) is [`downshift`](https://github.com/paypal/downshift)
-[🏎](https://github.com/paypal/downshift), but
+patterns) is [`downshift`](https://github.com/downshift-js/downshift)
+[🏎](https://github.com/downshift-js/downshift), but
 [I'm a little bit biased](https://blog.kentcdodds.com/introducing-downshift-for-react-b1de3fca0817)
 😅
 

--- a/content/blog/advanced-react-component-patterns/index.md
+++ b/content/blog/advanced-react-component-patterns/index.md
@@ -118,8 +118,7 @@ use case.
 My personal favorite implementation of this pattern (and some of the following
 patterns) is [`downshift`](https://github.com/downshift-js/downshift)
 [🏎](https://github.com/downshift-js/downshift), but
-[I'm a little bit biased](https://blog.kentcdodds.com/introducing-downshift-for-react-b1de3fca0817)
-😅
+[I'm a little bit biased](/blog/introducing-downshift-for-react) 😅
 
 ### Prop Collections and Getters
 

--- a/content/blog/application-state-management/index.md
+++ b/content/blog/application-state-management/index.md
@@ -67,7 +67,7 @@ continuing further.** It's super powerful on its own.
 Where things start to break down with component state is when you bump into
 problems with "prop drilling." Learn more about this here:
 
-[**Prop Drilling**](https://blog.kentcdodds.com/prop-drilling-bb62e02cb691)
+[**Prop Drilling**](/blog/prop-drilling)
 
 ### JavaScript Module (Singleton)
 
@@ -111,7 +111,7 @@ still not a bad option. That is,
 The new Context API in React is super duper awesome. If you haven't read my post
 about that yet, give it a look:
 
-[**React's ⚛️ new Context API**](https://kentcdodds.com/blog/reacts-new-context-api)
+[**React's ⚛️ new Context API**](/blog/reacts-new-context-api)
 
 React context allows you to overcome the prop-drilling problem _and_ the update
 issues with a singleton with a simple built-in API. With this API you can pretty

--- a/content/blog/authentication-in-react-applications/index.md
+++ b/content/blog/authentication-in-react-applications/index.md
@@ -72,7 +72,7 @@ the app or the other if there is no user.
 > If you want to just look at how it's all done, then you can checkout
 > [the bookshelf repo](https://github.com/kentcdodds/bookshelf) which I made for
 > my
-> [Build ReactJS Applications Workshop](https://kentcdodds.com/workshops/build-react-js-applications).
+> [Build ReactJS Applications Workshop](/workshops/build-react-js-applications).
 
 Ok, so what do you do to get to this point? Let's start by looking at where
 we're actually rendering the app:

--- a/content/blog/becoming-an-open-source-project-maintainer/index.md
+++ b/content/blog/becoming-an-open-source-project-maintainer/index.md
@@ -17,7 +17,7 @@ published over 100 packages to npm. Not all of them are widely used (or used at
 all), but many of them are. I have some ideas about how to maintain open source
 projects. I've given a talk on this in the past (unfortunately each time the
 recording sadly failed, but there's a practice run, so
-[check it out here](https://kentcdodds.com/talks/#managing-an-open-source-project)).
+[check it out here](/talks/#managing-an-open-source-project)).
 
 In this newsletter though, I want to talk about how you become a project
 maintainer. The easiest way to do this is to create your own project from
@@ -27,7 +27,7 @@ existing project. So how do you get involved?
 ![good question](./images/0.gif)
 
 Well,
-["You contribute best to something you use regularly."](https://blog.kentcdodds.com/what-open-source-project-should-i-contribute-to-7d50ecfe1cb4)
+["You contribute best to something you use regularly."](/blog/what-open-source-project-should-i-contribute-to)
 So before you decide you want to be a maintainer of a project, make sure it's
 one that you use yourself, otherwise you'll lose motivation pretty quickly.
 
@@ -67,7 +67,7 @@ you're willing and able and magic things happen.
 
 Now, I can't promise that you'll become a core maintainer of React if you start
 helping in issues and pull requests. But I can tell you that a lot of
-[the benefits of open source](https://blog.kentcdodds.com/how-getting-into-open-source-has-been-awesome-for-me-8480cd756a80)
+[the benefits of open source](/blog/how-getting-into-open-source-has-been-awesome-for-me)
 will come even if you aren't the project maintainer. And many projects really do
 need new maintainers (`angular-formly` included). You don't need permission to
 start acting like a maintainer. If you start doing the work, then it's pretty

--- a/content/blog/building-production-apps-100-in-the-browser/index.md
+++ b/content/blog/building-production-apps-100-in-the-browser/index.md
@@ -14,11 +14,10 @@ bannerCredit:
   [Unsplash](https://unsplash.com)'
 ---
 
-Earlier, [I mentioned](https://blog.kentcdodds.com/merry-christmas-77b4380b8cf9)
-that I made two apps for my family. The first is
-[Typing for Kids](https://typing-for-kids.netlify.com/) which I made for my two
-oldest children, the second is [Repeat Todo](https://repeat-todo.com/) which I
-made for my wife.
+Earlier, [I mentioned](/blog/merry-christmas) that I made two apps for my
+family. The first is [Typing for Kids](https://typing-for-kids.netlify.com/)
+which I made for my two oldest children, the second is
+[Repeat Todo](https://repeat-todo.com/) which I made for my wife.
 
 Today I want to briefly talk about how I went about creating these apps as a way
 to reiterate how awesome it is to build for the web these days.

--- a/content/blog/but-really-what-is-a-javascript-mock/index.md
+++ b/content/blog/but-really-what-is-a-javascript-mock/index.md
@@ -25,8 +25,8 @@ the content I'd prepared for time management purposes. So I've revamped
 (rewritten) the project to make it more conducive to learning and I split it
 into two parts:
 
-- [Testing Practices and Principles workshop](https://kentcdodds.com/workshops/#testing-practices-and-principles)
-- [Testing React and Web Applications](https://kentcdodds.com/workshops/#testing-react-and-web-applications)
+- [Testing Practices and Principles workshop](/workshops/#testing-practices-and-principles)
+- [Testing React and Web Applications](/workshops/#testing-react-and-web-applications)
 
 Last month I gave the Practices and Principles workshop at
 [Assert(JS)](https://www.assertjs.com/training). It was a lot of fun and went
@@ -35,7 +35,7 @@ the workshop was that I had more time to cover a subject I'd missed in the
 original workshop: **mocking**. I'd like to share that section with you in blog
 post form now because I think it's a good introduction. It follows the same
 pattern as my
-[But really, what is a JavaScript test?](https://blog.kentcdodds.com/but-really-what-is-a-javascript-test-46fe5f3fad77)
+[But really, what is a JavaScript test?](/blog/but-really-what-is-a-javascript-test)
 So here we go!
 
 > _If you'd like to follow along, go ahead and_ >

--- a/content/blog/but-really-what-is-a-javascript-test/index.md
+++ b/content/blog/but-really-what-is-a-javascript-test/index.md
@@ -308,9 +308,9 @@ which one to go about fixing.
 ### Step 5
 
 So all we need to do now is
-[write a CLI tool](https://blog.kentcdodds.com/tips-for-making-a-cli-based-tool-with-node-9903255c2a3b)
-that will search for all our test files and run them! That bit is pretty simple
-at first, but there are a LOT of things we can add on top of it. 😅
+[write a CLI tool](/blog/tips-for-making-a-cli-based-tool-with-node) that will
+search for all our test files and run them! That bit is pretty simple at first,
+but there are a LOT of things we can add on top of it. 😅
 
 At this point, we're building a testing framework and test runner. Luckily for
 us, there are a bunch of these built already! I've tried a ton of them and

--- a/content/blog/common-testing-mistakes/index.md
+++ b/content/blog/common-testing-mistakes/index.md
@@ -129,10 +129,10 @@ than you've likely experienced in the past. Repeat testing is a common mistake
 that people make when writing E2E tests that contribute to the poor performance
 and reliability.
 
-[Tests should always work in isolation](https://blog.kentcdodds.com/test-isolation-with-react-6962d3f13d1f).
-So that means every test should be executed as a different user. So every test
-will need to register and login as a brand new user right? Right. So you need to
-have a few page objects for the registration and login pages because you'll be
+[Tests should always work in isolation](/blog/test-isolation-with-react). So
+that means every test should be executed as a different user. So every test will
+need to register and login as a brand new user right? Right. So you need to have
+a few page objects for the registration and login pages because you'll be
 running through those pages in every test right? WRONG! That's the mistake!
 
 Let's take a step back. Why are you writing tests? So you can ship your

--- a/content/blog/compose-render-props/index.md
+++ b/content/blog/compose-render-props/index.md
@@ -26,8 +26,8 @@ The example itself is a little unimpressive from a user experience standpoint
 update it to look pretty). But the underlying code there is what I want to talk
 about.
 
-When I created [downshift](https://github.com/downshift-js/downshift), I gave it the
-following tagline:
+When I created [downshift](https://github.com/downshift-js/downshift), I gave it
+the following tagline:
 
 > _🏎 Primitives to build simple, flexible, WAI-ARIA compliant enhanced input
 > React components_
@@ -94,13 +94,13 @@ I hope this is helpful! Good luck!
 
 **Learn more about Render Props from me**:
 
-- [How to give rendering control to users with prop getters](https://blog.kentcdodds.com/how-to-give-rendering-control-to-users-with-prop-getters-549eaef76acf) — My
+- [How to give rendering control to users with prop getters](/blog/how-to-give-rendering-control-to-users-with-prop-getters) — My
   blog post from a few months back about a pattern that's complementary to
   render props
-- [Testing components using render props](https://blog.kentcdodds.com/testing--components-using-render-props-5623ab1814c) — If
+- [Testing components using render props](/blog/testing-components-using-render-props) — If
   you want to test component A which uses component B, and component B has a
   render prop API, read this.
-- [Answers to common questions about render props](https://blog.kentcdodds.com/answers-to-common-questions-about-render-props-a9f84bb12d5d) — My
+- [Answers to common questions about render props](/blog/answers-to-common-questions-about-render-props) — My
   blog post that is what the title says it is...
 - [egghead.io](https://egghead.io/courses/advanced-react-component-patterns) — My
   Advanced React Component Patterns course.

--- a/content/blog/compose-render-props/index.md
+++ b/content/blog/compose-render-props/index.md
@@ -26,7 +26,7 @@ The example itself is a little unimpressive from a user experience standpoint
 update it to look pretty). But the underlying code there is what I want to talk
 about.
 
-When I created [downshift](https://github.com/paypal/downshift), I gave it the
+When I created [downshift](https://github.com/downshift-js/downshift), I gave it the
 following tagline:
 
 > _🏎 Primitives to build simple, flexible, WAI-ARIA compliant enhanced input

--- a/content/blog/concerning-toolkits/index.md
+++ b/content/blog/concerning-toolkits/index.md
@@ -41,7 +41,7 @@ examples:
 [react-scripts](https://github.com/facebookincubator/create-react-app/tree/master/packages/react-scripts)
 (what [create-react-app](https://github.com/facebookincubator/create-react-app)
 leaves you with), my own
-[paypal-scripts/kcd-scripts](https://blog.kentcdodds.com/automation-without-config-412ab5e47229),
+[paypal-scripts/kcd-scripts](/blog/tools-without-config),
 [parcel](https://github.com/parcel-bundler/parcel),
 [preact-cli](https://github.com/developit/preact-cli),
 [ember-cli](https://ember-cli.com/) (the first widely used toolkit for JS), and
@@ -78,9 +78,8 @@ but maybe it'll help a bit with understanding the role that toolkits can play.
 
 People who are used to building/learning/configuring widely used tools have
 asked me why I would ever want to build and help popularize toolkits. Here are a
-few of the reasons
-[I'm working on toolkits](https://blog.kentcdodds.com/automation-without-config-412ab5e47229)
-for paypal and
+few of the reasons [I'm working on toolkits](/blog/tools-without-config) for
+paypal and
 [my own open source projects](https://github.com/kentcdodds/kcd-scripts).
 
 ### Keeping config updated

--- a/content/blog/control-props-vs-state-reducers/index.md
+++ b/content/blog/control-props-vs-state-reducers/index.md
@@ -23,9 +23,9 @@ Read more about the concept of control props in
 [the react docs](https://reactjs.org/docs/forms.html).
 
 You may not have had much experience with the idea of a
-[state reducer](https://blog.kentcdodds.com/the-state-reducer-pattern--b40316cfac57).
-In contrast to control props, built-in react elements don’t support state
-reducers (though I hear that reason-react does). My library
+[state reducer](/blog/the-state-reducer-pattern). In contrast to control props,
+built-in react elements don’t support state reducers (though I hear that
+reason-react does). My library
 [downshift](https://github.com/downshift-js/downshift) supports a state reducer.
 Here’s an example of using it to prevent the menu from closing after an item is
 selected:
@@ -47,7 +47,7 @@ const ui = (
 ```
 
 You can learn how to implement these patterns from
-[my Advanced React Component Patterns material](https://kentcdodds.com/workshops/#advanced-react-component-patterns).
+[my Advanced React Component Patterns material](/workshops/#advanced-react-component-patterns).
 
 Both of these patterns help you expose state management to component consumers
 and while they have significantly different APIs, they allow much of the same

--- a/content/blog/control-props-vs-state-reducers/index.md
+++ b/content/blog/control-props-vs-state-reducers/index.md
@@ -26,7 +26,7 @@ You may not have had much experience with the idea of a
 [state reducer](https://blog.kentcdodds.com/the-state-reducer-pattern--b40316cfac57).
 In contrast to control props, built-in react elements don’t support state
 reducers (though I hear that reason-react does). My library
-[downshift](https://github.com/paypal/downshift) supports a state reducer.
+[downshift](https://github.com/downshift-js/downshift) supports a state reducer.
 Here’s an example of using it to prevent the menu from closing after an item is
 selected:
 

--- a/content/blog/dealing-with-fomo/index.md
+++ b/content/blog/dealing-with-fomo/index.md
@@ -93,8 +93,7 @@ of ourselves and find more happiness in life :) Good luck!
 - [**UPDATED**: Advanced React Component Patterns](http://kcd.im/advanced-react) — This
   is the [egghead.io](http://egghead.io/) version of my course material
   completely updated for the latest in React with **NEW PATTERNS** (like
-  [the state reducer prop pattern](https://blog.kentcdodds.com/the-state-reducer-pattern--b40316cfac57)).
-  Enjoy!
+  [the state reducer prop pattern](/blog/the-state-reducer-pattern)). Enjoy!
 - [Drive with Kent — Tech phone call recording](https://www.youtube.com/watch?v=vVlcq3e1ooI) — In
   case you missed it,
   [I took a 6 hour drive](https://github.com/kentcdodds/ama/issues/405) and had

--- a/content/blog/downshift-2-0-0-released/index.md
+++ b/content/blog/downshift-2-0-0-released/index.md
@@ -34,13 +34,13 @@ heard of downshift, consider reading
 
 Lead primarily by [Michael Ball](https://github.com/cycomachead) (with helpful
 reviews from several others), we
-[received](https://github.com/paypal/downshift/pull/285) a number of
+[received](https://github.com/downshift-js/downshift/pull/285) a number of
 improvements to the accessibility features baked-into downshift. He also added a
 new
-[`getMenuProps`](https://github.com/paypal/downshift/blob/master/README.md#getmenuprops)
+[`getMenuProps`](https://github.com/downshift-js/downshift/blob/master/README.md#getmenuprops)
 [prop getter](https://blog.kentcdodds.com/how-to-give-rendering-control-to-users-with-prop-getters-549eaef76acf)
 (which was also instrumental in fixing
-[a bug with React Portals](https://github.com/paypal/downshift/issues/287)).
+[a bug with React Portals](https://github.com/downshift-js/downshift/issues/287)).
 This allows us to add some `aria-` attributes to the menu you render that will
 help assistive technologies use your enhanced input components! Woo! I've also
 updated many of the examples to use more semantically correct elements.
@@ -53,13 +53,13 @@ that this is great! This is largely thanks to work by
 [Eli Perkins](https://github.com/eliperkins)! They've already shipped downshift
 to production in their iOS app:
 
-[![Screenshot of downshift code in React Native from Eli](./images/0.png)](https://github.com/paypal/downshift/issues/185#issuecomment-365965566)
+[![Screenshot of downshift code in React Native from Eli](./images/0.png)](https://github.com/downshift-js/downshift/issues/185#issuecomment-365965566)
 
 ### ReasonReact Support
 
 We've actually had this for a while too, but I want to call it out especially.
 Thanks to [Nicola Molinari](https://github.com/emmenko) there are
-[official Reason bindings for downshift](https://github.com/paypal/downshift/blob/master/README.md#bindings-for-reasonml).
+[official Reason bindings for downshift](https://github.com/downshift-js/downshift/blob/master/README.md#bindings-for-reasonml).
 So you can build UIs for any platform you can imagine with downshift and
 [ReasonML](https://reasonml.github.io/). Soooo cool!
 
@@ -80,7 +80,7 @@ support `children`.
 
 After downshift was out for a while, I started to realize that folks missed out
 on some of the more useful and necessary props (like
-[`itemToString`](https://github.com/paypal/downshift/blob/master/README.md#itemtostring)).
+[`itemToString`](https://github.com/downshift-js/downshift/blob/master/README.md#itemtostring)).
 I blame myself for this and recently reorganized the docs to make more relevant
 information more apparent.
 
@@ -142,4 +142,4 @@ people:
 
 Thank you!
 
-[_See the release notes for more info on this release_](https://github.com/paypal/downshift/releases/tag/v2.0.0)
+[_See the release notes for more info on this release_](https://github.com/downshift-js/downshift/releases/tag/v2.0.0)

--- a/content/blog/downshift-2-0-0-released/index.md
+++ b/content/blog/downshift-2-0-0-released/index.md
@@ -28,7 +28,7 @@ going to do it now:
 
 Woo! So what do you have to look forward to? Let's dive in! (If you haven't
 heard of downshift, consider reading
-[the original release post](https://blog.kentcdodds.com/introducing-downshift-for-react-b1de3fca0817)).
+[the original release post](/blog/introducing-downshift-for-react)).
 
 ### Improved Accessibility ([**#a11y**](https://twitter.com/hashtag/a11y))
 
@@ -38,7 +38,7 @@ reviews from several others), we
 improvements to the accessibility features baked-into downshift. He also added a
 new
 [`getMenuProps`](https://github.com/downshift-js/downshift/blob/master/README.md#getmenuprops)
-[prop getter](https://blog.kentcdodds.com/how-to-give-rendering-control-to-users-with-prop-getters-549eaef76acf)
+[prop getter](/blog/how-to-give-rendering-control-to-users-with-prop-getters)
 (which was also instrumental in fixing
 [a bug with React Portals](https://github.com/downshift-js/downshift/issues/287)).
 This allows us to add some `aria-` attributes to the menu you render that will

--- a/content/blog/effective-snapshot-testing/index.md
+++ b/content/blog/effective-snapshot-testing/index.md
@@ -105,8 +105,7 @@ console for the developers using your tool. Before snapshot testing I would
 always write a silly regex that got the basic gist of what the message should
 say, but with snapshot testing it's so much easier.
 
-Here's an example of this from
-[kcd-scripts](https://blog.kentcdodds.com/automation-without-config-412ab5e47229):
+Here's an example of this from [kcd-scripts](/blog/tools-without-config):
 
 - [Tests](https://github.com/kentcdodds/kcd-scripts/blob/11f6218772ee2075cebddadd30a50a6d4bdec637/src/__tests__/index.js)
 - [Snapshot output](https://github.com/kentcdodds/kcd-scripts/blob/11f6218772ee2075cebddadd30a50a6d4bdec637/src/__tests__/__snapshots__/index.js.snap)

--- a/content/blog/full-time-educator/index.md
+++ b/content/blog/full-time-educator/index.md
@@ -14,7 +14,7 @@ banner: './banner.jpg'
 ---
 
 I've been teaching for as long as I can remember. I talk about this a lot in
-["Why and How I started public speaking"](https://blog.kentcdodds.com/d5ae78303707),
+["Why and How I started public speaking"](/blog/why-and-how-i-started-public-speaking),
 but just know that I have a love of teaching, I've done it a lot, and I want to
 do more. **This is why I'm excited to announce that I've gone full-time
 educator!**

--- a/content/blog/getting-noticed-and-widening-your-reach/index.md
+++ b/content/blog/getting-noticed-and-widening-your-reach/index.md
@@ -114,8 +114,7 @@ sacrificing your well-being and relationships. That's a subject for another blog
 post. Just know that working on building a community by
 [creating fantastic documentation](https://twitter.com/kentcdodds/status/582620905433489408)(including
 [several free egghead.io lessons](http://docs.angular-formly.com/docs/learn-angular-formly)),
-[encouraging contribution](https://blog.kentcdodds.com/first-timers-only-78281ea47455),
-and
+[encouraging contribution](/blog/first-timers-only), and
 [recognizing and trusting contributors](https://github.com/all-contributors/all-contributors)
 is an important part of getting adoption and recognition for your open source
 work.
@@ -147,12 +146,12 @@ I also did _not_ attempt to throw shade at alternatives or downplay the value of
 their abstractions. Being unkind to the hard work of other people is a very poor
 way to promote your project and has no good place in the world.
 
-### [Speaking](https://kentcdodds.com/talks) & [Teaching](https://kentcdodds.com/workshops)
+### [Speaking](/talks) & [Teaching](/workshops)
 
 ![me teaching people at a workshop](./images/0.jpeg)
 
 I recently published a blog post called
-[Why and How I started public speaking](https://blog.kentcdodds.com/why-and-how-i-started-public-speaking-d5ae78303707).
+[Why and How I started public speaking](/blog/why-and-how-i-started-public-speaking).
 I'm just going to link you to that story rather than re-iterate the whole thing
 here. But I do want to tell how I got started with creating content for
 [egghead.io](http://egghead.io/) as that made a big influence on widening my
@@ -265,15 +264,15 @@ you as well and many become your followers. **I think that of all things, my
 podcasts had the biggest impact on my reach while I was running them.**
 
 The show did prove to take more time than I had, so I did eventually
-[Sunset JavaScript Air](https://blog.kentcdodds.com/sunsetting-javascript-air-2e9d3700dbd4).
-But maybe one day I'll start it back up again. It was awesome.
+[Sunset JavaScript Air](/blog/sunsetting-javascript-air). But maybe one day I'll
+start it back up again. It was awesome.
 
 > _I'll just add here really quick that I'm also way more likely to be able to
 > give you an hour of my time if I know that the value we create will be spread
 > to impact more people. I'm always happy to join you on a podcast._ >
-> [_Here's a list of podcasts I've been a guest on in the past_](https://kentcdodds.com/appearances/)_._
+> [_Here's a list of podcasts I've been a guest on in the past_](/appearances)_._
 
-### [Newslettering](http://kcd.im/news) & [Blogging](https://blog.kentcdodds.com/)
+### [Newslettering](http://kcd.im/news) & [Blogging](/blog)
 
 ![A notebook and a pen](./images/3.jpg)
 

--- a/content/blog/getting-noticed-and-widening-your-reach/index.md
+++ b/content/blog/getting-noticed-and-widening-your-reach/index.md
@@ -116,7 +116,7 @@ post. Just know that working on building a community by
 [several free egghead.io lessons](http://docs.angular-formly.com/docs/learn-angular-formly)),
 [encouraging contribution](https://blog.kentcdodds.com/first-timers-only-78281ea47455),
 and
-[recognizing and trusting contributors](https://github.com/kentcdodds/all-contributors)
+[recognizing and trusting contributors](https://github.com/all-contributors/all-contributors)
 is an important part of getting adoption and recognition for your open source
 work.
 

--- a/content/blog/giving-good-demos/index.md
+++ b/content/blog/giving-good-demos/index.md
@@ -18,9 +18,8 @@ bannerCredit:
 [I hit two big milestones for projects I've been working on for a long time](https://twitter.com/kentcdodds/status/931247165342707712).
 I finished the second of two React courses for [egghead.io](http://egghead.io/)
 and [Jamund Ferguson](https://twitter.com/xjamundx) and I gave a demo and the
-announcement of
-[paypal-scripts](https://blog.kentcdodds.com/automation-without-config-412ab5e47229)
-at work. And it went super well! Hooray!
+announcement of [paypal-scripts](/blog/tools-without-config) at work. And it
+went super well! Hooray!
 
 ![Hooray!](./images/0.gif)
 

--- a/content/blog/hi-thanks-for-reaching-out-to-me/index.md
+++ b/content/blog/hi-thanks-for-reaching-out-to-me/index.md
@@ -14,12 +14,12 @@ bannerCredit: >-
 Last night I got two emails requesting webpack support. This is not new nor
 surprising. I get support emails _all the time_ (as I'm writing this, I just got
 another support request via gitter on an old library I used to maintain). I
-think it has to do with all the [workshops](https://kentcdodds.com/workshops/)
-and [talks](https://kentcdodds.com/talks/) I've given. People have questions
-about the stuff I create and want help with it. Totally understandable. When I
-have a question, I'd much rather talk to an expert on the subject than read
-generic documentation or outdated tutorials (this is one of the reasons that I
-do my [tech chats](https://github.com/kentcdodds/ama/issues/125)).
+think it has to do with all the [workshops](/workshops) and [talks](/talks) I've
+given. People have questions about the stuff I create and want help with it.
+Totally understandable. When I have a question, I'd much rather talk to an
+expert on the subject than read generic documentation or outdated tutorials
+(this is one of the reasons that I do my
+[tech chats](https://github.com/kentcdodds/ama/issues/125)).
 
 Unfortunately, I don't have time to field all of the support requests that I get
 via email, GitHub, Twitter, Gitter, Slack, etc... It's not that I don't want to

--- a/content/blog/how-i-am-so-productive/index.md
+++ b/content/blog/how-i-am-so-productive/index.md
@@ -32,15 +32,14 @@ basis these days:
   with
   [new friends playing Dominion](https://twitter.com/craigwalker1123/status/1039138835714560000))
 - On Mondays, I publish the blogpost newsletter from two weeks ago to
-  [blog.kentcdodds.com](http://blog.kentcdodds.com/), a new one for subscribers.
+  [kentcdodds.com/blog](http://kentcdodds.com/blog), a new one for subscribers.
   (~1.5 hours of work, depending...)
 - Product tasks (currently helping work on [paypal.me](https://paypal.me/))
   (this is normally where most of my weekday is spent)
 - Attend work meetings
 - Help people on slack/video chat
-- Work on
-  [paypal-scripts](https://blog.kentcdodds.com/automation-without-config-412ab5e47229)
-  (among other internal libraries and tools)
+- Work on [paypal-scripts](/blog/tools-without-config) (among other internal
+  libraries and tools)
 - traveling/training (about once a quarter. I'm on an airplane right now for
   such an engagement)
 - Research, prepare, and do a
@@ -189,9 +188,9 @@ years I've been using an awesome tool called
 to automatically release my packages.
 
 The concept of automation is something
-[I've written about in the past](https://blog.kentcdodds.com/an-argument-for-automation-fce8394c14e2).
-It's how I got into software development and I feel strongly that automation is
-the way we can make ourselves more productive
+[I've written about in the past](/blog/automation). It's how I got into software
+development and I feel strongly that automation is the way we can make ourselves
+more productive
 ([even if it takes longer to develop the automation than the time it would save us](https://xkcd.com/1205/)).
 If you find yourself repeatedly doing a task, see if there's a simple way to
 automate it. (Like
@@ -218,8 +217,7 @@ I learned early on that people ask me repeat questions early on. I like to give
 them answers, but I also found out quickly that
 [I don't have time to answer everyone](http://kcd.im/no-time) and it's a bit
 frustrating to answer the same question multiple times. This is why having
-[an active blog](https://blog.kentcdodds.com/) and [an AMA](http://kcd.im/ama)
-are super helpful.
+[an active blog](/blog) and [an AMA](http://kcd.im/ama) are super helpful.
 
 If someone asks me a question, 99% of the time I'll ask them to ask it on my
 AMA. If I get the same question many times, then I'll make it the subject of a
@@ -371,7 +369,7 @@ inbox two weeks before it's published to my blog:
 
 **Learn more about career development from me**:
 
-- [Why and How I started public speaking](https://blog.kentcdodds.com/why-and-how-i-started-public-speaking-d5ae78303707)
+- [Why and How I started public speaking](/blog/why-and-how-i-started-public-speaking)
 - [Getting Noticed and Widening Your Reach](https://buttondown.email/kentcdodds/archive/03761505-8609-404c-a5b7-5367013292bf)
 - [Zero to 60 in Software Development: How to Jumpstart Your Career — Forward 4 Web Summit](https://www.youtube.com/watch?v=-qPh6I2hfjw&list=PLV5CVI1eNcJgNqzNwcs4UKrlJdhfDjshf)
 

--- a/content/blog/how-i-am-so-productive/index.md
+++ b/content/blog/how-i-am-so-productive/index.md
@@ -207,9 +207,10 @@ better).
 Many of those releases of my open source projects I do are releasing code that I
 did not write. I put forth an investment of time in helping
 [and teaching](http://kcd.im/pull-request) other people contribute to my
-projects and [do things](https://github.com/kentcdodds/all-contributors) to help
-motivate people to do so. This means that I'm able to do more because other
-people handle a lot of project maintenance for me so I can do other things.
+projects and [do things](https://github.com/all-contributors/all-contributors)
+to help motivate people to do so. This means that I'm able to do more because
+other people handle a lot of project maintenance for me so I can do other
+things.
 
 ### Don't answer the same question twice
 

--- a/content/blog/how-i-learn-an-open-source-codebase/index.md
+++ b/content/blog/how-i-learn-an-open-source-codebase/index.md
@@ -15,7 +15,7 @@ bannerCredit:
   [Unsplash](https://unsplash.com/search/photos/community)'
 ---
 
-[Participating in open source has been awesome for me](https://blog.kentcdodds.com/how-getting-into-open-source-has-been-awesome-for-me-8480cd756a80).
+[Participating in open source has been awesome for me](/blog/how-getting-into-open-source-has-been-awesome-for-me).
 It has
 [made me and the stuff I make better](https://www.youtube.com/watch?v=6mtPPkKchcQ&list=PLV5CVI1eNcJgNqzNwcs4UKrlJdhfDjshf).
 A [common](https://github.com/kentcdodds/ama/issues/57)
@@ -28,7 +28,7 @@ I make an important observation:
 
 > You contribute best to something you use regularly.
 
-[**Open Source Stamina**](https://blog.kentcdodds.com/open-source-stamina-dafd063f9932)
+[**Open Source Stamina**](/blog/open-source-stamina)
 
 So while it can be a lot of fun to just jump into any open source project and
 help out. Sustainable contributions are best found in projects that you use on a
@@ -71,7 +71,7 @@ In my blogpost
 ["What open source project should I contribute to?"](https://medium.com/@kentcdodds/what-open-source-project-should-i-contribute-to-7d50ecfe1cb4)
 I talk a little bit about how to find where the code is for a specific API.
 
-[**What open source project should I contribute to?**](https://blog.kentcdodds.com/what-open-source-project-should-i-contribute-to-7d50ecfe1cb4)
+[**What open source project should I contribute to?**](/blog/what-open-source-project-should-i-contribute-to)
 
 ### Break things
 
@@ -115,7 +115,7 @@ I hope this is helpful! Good luck!
   [egghead.io](http://egghead.io/), absolutely free!)
 - [Creating an Open Source JavaScript Library on Github](https://frontendmasters.com/courses/open-source/)
   (on Frontend Masters, subscribers only).
-- [My Talks](https://kentcdodds.com/talks/) — I've got several about open source
+- [My Talks](/talks) — I've got several about open source
 
 **Things to not miss**:
 

--- a/content/blog/how-to-give-rendering-control-to-users-with-prop-getters/index.md
+++ b/content/blog/how-to-give-rendering-control-to-users-with-prop-getters/index.md
@@ -25,7 +25,7 @@ Since I
 [released downshift 🏎](https://kentcdodds.com/blog/introducing-downshift-for-react)
 a few weeks ago. Of all things, I think the most common question I've gotten has
 been about the "prop getters." As far as I know,
-[downshift](https://github.com/paypal/downshift) is the first library to
+[downshift](https://github.com/downshift-js/downshift) is the first library to
 implement this pattern, so I thought I'd explain why it's useful and how to
 implement it. If you're unfamiliar with downshift, please read
 [the intro post](https://kentcdodds.com/blog/introducing-downshift-for-react)
@@ -225,8 +225,8 @@ use the `children` prop, but you could use a `render` prop if you prefer).
 
 Here are a few projects that implement the prop getters pattern:
 
-- `[downshift](https://github.com/paypal/downshift)`
-  [🏎](https://github.com/paypal/downshift) - Primitive for building simple,
+- `[downshift](https://github.com/downshift-js/downshift)`
+  [🏎](https://github.com/downshift-js/downshift) - Primitive for building simple,
   flexible, WAI-ARIA compliant enhanced input React components
 - `[react-toggled](https://github.com/kentcdodds/react-toggled)` - Component to
   build simple, flexible, and accessible toggle components

--- a/content/blog/how-to-give-rendering-control-to-users-with-prop-getters/index.md
+++ b/content/blog/how-to-give-rendering-control-to-users-with-prop-getters/index.md
@@ -21,15 +21,14 @@ bannerCredit:
 > and
 > [Use Prop Getters with Render Props](https://egghead.io/lessons/react-use-prop-getters-with-render-props)
 
-Since I
-[released downshift 🏎](https://kentcdodds.com/blog/introducing-downshift-for-react)
-a few weeks ago. Of all things, I think the most common question I've gotten has
-been about the "prop getters." As far as I know,
+Since I [released downshift 🏎](/blog/introducing-downshift-for-react) a few
+weeks ago. Of all things, I think the most common question I've gotten has been
+about the "prop getters." As far as I know,
 [downshift](https://github.com/downshift-js/downshift) is the first library to
 implement this pattern, so I thought I'd explain why it's useful and how to
 implement it. If you're unfamiliar with downshift, please read
-[the intro post](https://kentcdodds.com/blog/introducing-downshift-for-react)
-before you continue. Don't worry, I'll wait...
+[the intro post](/blog/introducing-downshift-for-react) before you continue.
+Don't worry, I'll wait...
 
 ![dog wagging the tail while waiting](./images/0.gif)
 
@@ -226,8 +225,8 @@ use the `children` prop, but you could use a `render` prop if you prefer).
 Here are a few projects that implement the prop getters pattern:
 
 - `[downshift](https://github.com/downshift-js/downshift)`
-  [🏎](https://github.com/downshift-js/downshift) - Primitive for building simple,
-  flexible, WAI-ARIA compliant enhanced input React components
+  [🏎](https://github.com/downshift-js/downshift) - Primitive for building
+  simple, flexible, WAI-ARIA compliant enhanced input React components
 - `[react-toggled](https://github.com/kentcdodds/react-toggled)` - Component to
   build simple, flexible, and accessible toggle components
 - `[dub-step](https://github.com/infiniteluke/dub-step)`

--- a/content/blog/how-to-know-what-to-test/index.md
+++ b/content/blog/how-to-know-what-to-test/index.md
@@ -20,7 +20,7 @@ tests for specific scenarios, and so on. But knowing _how_ to write tests is
 only half the battle to achieve confidence in your application. Knowing _what_
 to test is the other–very important–battle.
 
-In my [workshop material](https://kentcdodds.com/workshops) and on
+In my [workshop material](/workshops) and on
 [TestingJavaScript.com](https://testingjavascript.com), I do talk about how to
 know what to test, but I get asked about this enough that I thought it would be
 good to write a blog post about it. So here you go!

--- a/content/blog/how-to-make-the-most-out-of-conferences/index.md
+++ b/content/blog/how-to-make-the-most-out-of-conferences/index.md
@@ -103,7 +103,7 @@ I think :)
 
 This is a subject unto itself (I actually talked about it in last week's
 newsletter
-["Why and How I started public speaking"](https://blog.kentcdodds.com/why-and-how-i-started-public-speaking-d5ae78303707)),
+["Why and How I started public speaking"](/blog/why-and-how-i-started-public-speaking)),
 but I would encourage you to get involved in speaking at conferences. This does
 add a whole new layer of stress to your experience, but there are a great deal
 of benefits as well. I definitely encourage speaking as a way to get to attend

--- a/content/blog/how-to-react/index.md
+++ b/content/blog/how-to-react/index.md
@@ -16,9 +16,8 @@ bannerCredit:
 ---
 
 This last week I gave
-[a talk at React Dev Summit called "How to React."](https://kentcdodds.com/talks/#how-to-react).
-It's basically an updated version of
-[Pete Hunt's](https://twitter.com/floydophone)
+[a talk at React Dev Summit called "How to React."](/talks/#how-to-react). It's
+basically an updated version of [Pete Hunt's](https://twitter.com/floydophone)
 [react-howto](https://github.com/petehunt/react-howto) GitHub repo. I thought
 I'd just jot down a few things from this talk for you to enjoy in your inbox
 today :)
@@ -120,8 +119,8 @@ all to use React.
 
 [The last lesson](https://egghead.io/lessons/egghead-build-and-deploy-a-react-application)
 shows you how to use [CodeSandbox.io](http://codesandbox.io/) to create your app
-[entirely in the browser](https://blog.kentcdodds.com/building-production-apps-100-in-the-browser-a8b5da7faf3)
-and download that to your computer to a
+[entirely in the browser](/blog/building-production-apps-100-in-the-browser) and
+download that to your computer to a
 [create-react-app](https://github.com/facebook/create-react-app) application.
 
 You don't need anything installed to get a really long way! And once you do, you
@@ -169,8 +168,8 @@ actually get you a long way with React and I encourage you to keep doing this as
 long as you're able. Eventually you'll start running into some trouble with "the
 prop-drilling problem." You'll know it when you feel it. When this happens, then
 I suggest you give my blog post
-["Application State Management"](https://blog.kentcdodds.com/application-state-management-66de608ccb24)
-a read through.
+["Application State Management"](/blog/application-state-management) a read
+through.
 
 > _TL;DR: Singleton Module -> React.createContext ->_ >
 > [_Unstated.io_](http://unstated.io/)_-\> redux._

--- a/content/blog/improving-the-usability-of-your-modules/index.md
+++ b/content/blog/improving-the-usability-of-your-modules/index.md
@@ -219,8 +219,7 @@ Good luck! And stay awesome 😎
   awesome so I'm glad it's pushing forward!
 - [Did you know...](https://blog.kentcdodds.com/did-you-know-3079d5aec43b) by
   me. Something you might not have known about Medium before and now that you do
-  I'd appreciate you applying that knowledge to
-  [the things I publish](https://blog.kentcdodds.com/) 😉
+  I'd appreciate you applying that knowledge to [the things I publish](/blog) 😉
 - [Flexbox Zombies](http://geddski.teachable.com/p/flexbox-zombies). The best
   way to learn flexbox by the amazing
   [Dave Geddes](https://twitter.com/geddski). Also check out

--- a/content/blog/introducing-downshift-for-react/index.md
+++ b/content/blog/introducing-downshift-for-react/index.md
@@ -17,7 +17,7 @@ bannerCredit:
   [Unsplash](https://unsplash.com)'
 ---
 
-[_downshift 🏎_](https://github.com/paypal/downshift) _is the primitive you need
+[_downshift 🏎_](https://github.com/downshift-js/downshift) _is the primitive you need
 to build simple, flexible, WAI-ARIA compliant React
 autocomplete/typeahead/dropdown/select/combobox/etc (AKA "item selection")
 (p)react ⚛️ components. From PayPal 💙_
@@ -38,7 +38,7 @@ autocomplete. Specifically for React, there's
 [react-autocomplete](https://github.com/reactjs/react-autocomplete), and
 [more](https://www.npmjs.com/search?q=react%20autocomplete). And now there's
 another one on the scene. It's called
-[downshift](https://github.com/paypal/downshift), its emoji is the race car 🏎,
+[downshift](https://github.com/downshift-js/downshift), its emoji is the race car 🏎,
 and it's taking a different approach.
 
 ## The state of item selection
@@ -74,10 +74,10 @@ value and flexibility.
 ## render callback
 
 _There's actually not one instance of React.createElement (or JSX) anywhere in
-the_ [`downshift`](https://github.com/paypal/downshift/tree/master/src)
-[_source code_](https://github.com/paypal/downshift/tree/master/src)_._ Instead,
-[`downshift`](https://github.com/paypal/downshift/blob/a449a3b115e4253c7547b404e1059422ae9bf165/src/downshift.js#L710)
-[uses a render callback](https://github.com/paypal/downshift/blob/a449a3b115e4253c7547b404e1059422ae9bf165/src/downshift.js#L710)
+the_ [`downshift`](https://github.com/downshift-js/downshift/tree/master/src)
+[_source code_](https://github.com/downshift-js/downshift/tree/master/src)_._ Instead,
+[`downshift`](https://github.com/downshift-js/downshift/blob/a449a3b115e4253c7547b404e1059422ae9bf165/src/downshift.js#L710)
+[uses a render callback](https://github.com/downshift-js/downshift/blob/a449a3b115e4253c7547b404e1059422ae9bf165/src/downshift.js#L710)
 (following
 [the render prop pattern](https://cdb.reacttraining.com/use-a-render-prop-50de598f11ce)).
 This allows you to render whatever you want inside `<Downshift />` . It also
@@ -198,9 +198,9 @@ use `downshift` to implement a dropdown without any trouble too.
 
 There are other prop getters available (some are there just to make
 accessibility easier). See
-[the](https://github.com/paypal/downshift/blob/8563d4bae2af19fdc7242c66b551d46396234cf9/README.md#prop-getters)
-[`downshift`](https://github.com/paypal/downshift/blob/8563d4bae2af19fdc7242c66b551d46396234cf9/README.md#prop-getters)
-[docs](https://github.com/paypal/downshift/blob/8563d4bae2af19fdc7242c66b551d46396234cf9/README.md#prop-getters)
+[the](https://github.com/downshift-js/downshift/blob/8563d4bae2af19fdc7242c66b551d46396234cf9/README.md#prop-getters)
+[`downshift`](https://github.com/downshift-js/downshift/blob/8563d4bae2af19fdc7242c66b551d46396234cf9/README.md#prop-getters)
+[docs](https://github.com/downshift-js/downshift/blob/8563d4bae2af19fdc7242c66b551d46396234cf9/README.md#prop-getters)
 for more info.
 
 ## controlled props
@@ -241,7 +241,7 @@ easy to get right for an item selection component like autocomplete. While
 developing it, I referenced several autocomplete components and
 [Marcy Sutton](https://medium.com/u/18a4cb7bfaf) was kind enough to give one of
 our examples
-[an accessibility audit](https://github.com/paypal/downshift/issues/79) (Thank
+[an accessibility audit](https://github.com/downshift-js/downshift/issues/79) (Thank
 you Marcy!). Pull up [an example](https://3kxm9wk791.codesandbox.io/) with
 [VoiceOver](https://www.apple.com/accessibility/mac/vision/) and I think you'll
 be impressed! We've worked hard to make sure that it's accessible
@@ -293,7 +293,7 @@ applications right now as well.
 I
 [started working on downshift](https://www.youtube.com/watch?v=2kzD1IjDy5s&list=PLV5CVI1eNcJh5CTgArGVwANebCrAh2OUE&index=11)
 about a month ago, the first beta was published (as
-[react-autocompletely](https://github.com/paypal/downshift/issues/10)) the next
+[react-autocompletely](https://github.com/downshift-js/downshift/issues/10)) the next
 day. It's slowly been gaining popularity (it already has 900 🌟 and 7k
 downloads/month) even before the official 1.0.0 release! So it's definitely
 being used in several places, but the first production deployment that I'm aware
@@ -336,11 +336,11 @@ the airport ✈️ That made a big difference in the direction of the API as wel
 Special shoutout to [Travis Arnold](https://medium.com/u/4052582a8a85),
 [Julien Goux](https://medium.com/u/83db96e5266d),
 [the_Simian](https://medium.com/u/f7fbdc8cd7ea), and
-[all the contributors](https://github.com/paypal/downshift/blob/master/README.md#contributors)
-([so far](https://github.com/paypal/downshift/issues)) for their help with
+[all the contributors](https://github.com/downshift-js/downshift/blob/master/README.md#contributors)
+([so far](https://github.com/downshift-js/downshift/issues)) for their help with
 forming the `downshift` API into what it is now.
 
 Please give `downshift`
-[a star 🌟](https://github.com/paypal/downshift/stargazers),
-[a watch 👀](https://github.com/paypal/downshift/watchers), and
+[a star 🌟](https://github.com/downshift-js/downshift/stargazers),
+[a watch 👀](https://github.com/downshift-js/downshift/watchers), and
 [a try 😎](http://kcd.im/ds-example).

--- a/content/blog/introducing-the-react-testing-library/index.md
+++ b/content/blog/introducing-the-react-testing-library/index.md
@@ -16,7 +16,7 @@ bannerCredit:
 ---
 
 Two weeks ago, I wrote
-[a new library](https://github.com/kentcdodds/react-testing-library)! I've been
+[a new library](https://github.com/testing-library/react-testing-library)! I've been
 thinking about it for a while. But two weeks ago I started getting pretty
 serious about it:
 
@@ -24,7 +24,7 @@ https://twitter.com/kentcdodds/status/974278185540964352
 
 Read on to get an idea of what I mean by "damaging practices."
 
-### [react-testing-library](https://github.com/kentcdodds/react-testing-library)
+### [react-testing-library](https://github.com/testing-library/react-testing-library)
 
 ![The library emoji is the goat. No particular reason...](./images/0.png)
 
@@ -67,11 +67,11 @@ This library is a replacement for [enzyme](http://airbnb.io/enzyme/). While you
 _can_ follow these guidelines using enzyme itself, enforcing this is harder
 because of all the extra utilities that enzyme provides (utilities which
 facilitate testing implementation details). Read more about this in
-[the FAQ](https://github.com/kentcdodds/react-testing-library/blob/master/README.md#faq).
+[the FAQ](https://github.com/testing-library/react-testing-library/blob/master/README.md#faq).
 
 Also, while the react-testing-library is intended for react-dom, it can support
 React Native with
-[this short setup file](https://github.com/kentcdodds/react-testing-library/issues/22#issuecomment-376756260).
+[this short setup file](https://github.com/testing-library/react-testing-library/issues/22#issuecomment-376756260).
 
 **What this library is not**:
 
@@ -175,50 +175,50 @@ by [Jamie White](https://medium.com/u/76c97151e2a6), I added several more and
 now I'm even happier with this solution.
 
 You can read more about the library and its APIs in
-[the official docs](https://github.com/kentcdodds/react-testing-library). Here's
+[the official docs](https://github.com/testing-library/react-testing-library). Here's
 a high-level overview of what this library gives you:
 
-- [`Simulate`](https://github.com/kentcdodds/react-testing-library/blob/fd2df8d18652786a95bce34741180137f9d2cef2/README.md#simulate):
+- [`Simulate`](https://github.com/testing-library/react-testing-library/blob/fd2df8d18652786a95bce34741180137f9d2cef2/README.md#simulate):
   a re-export from the `Simulate` utility from
   [the](https://reactjs.org/docs/test-utils.html#simulate)
   [`react-dom/test-utils`](https://reactjs.org/docs/test-utils.html#simulate)
   [](https://reactjs.org/docs/test-utils.html#simulate)
   [`Simulate`](https://reactjs.org/docs/test-utils.html#simulate)
   [object](https://reactjs.org/docs/test-utils.html#simulate).
-- [`wait`](https://github.com/kentcdodds/react-testing-library/blob/fd2df8d18652786a95bce34741180137f9d2cef2/README.md#wait):
+- [`wait`](https://github.com/testing-library/react-testing-library/blob/fd2df8d18652786a95bce34741180137f9d2cef2/README.md#wait):
   allows you to wait for a non-deterministic period of time in your tests.
   Normally you should
-  [mock out API requests](https://github.com/kentcdodds/react-testing-library/blob/master/src/__tests__/fetch.js)
+  [mock out API requests](https://github.com/testing-library/react-testing-library/blob/master/src/__tests__/fetch.js)
   or
-  [animations](https://github.com/kentcdodds/react-testing-library/blob/master/src/__tests__/mock.react-transition-group.js),
+  [animations](https://github.com/testing-library/react-testing-library/blob/master/src/__tests__/mock.react-transition-group.js),
   but even if you're dealing with immediately resolved promises, you'll need
   your tests to wait for the next tick of the event loop and `wait` is really
   good for that. (Big shout out to
   [Łukasz Gozda Gandecki](https://medium.com/u/66ce121c68eb) who
-  [introduced this](https://github.com/kentcdodds/react-testing-library/issues/21)
+  [introduced this](https://github.com/testing-library/react-testing-library/issues/21)
   as a replacement for the (now deprecated)`flushPromises` API).
-- [`render`](https://github.com/kentcdodds/react-testing-library/blob/fd2df8d18652786a95bce34741180137f9d2cef2/README.md#render):
+- [`render`](https://github.com/testing-library/react-testing-library/blob/fd2df8d18652786a95bce34741180137f9d2cef2/README.md#render):
   This is the meat of the library. It's fairly simple. It creates a `div`with
   `document.createElement`, then uses `ReactDOM.render` to render to that `div`.
 
 The `render` function returns the following objects and utilities:
 
-- [`container`](https://github.com/kentcdodds/react-testing-library/blob/fd2df8d18652786a95bce34741180137f9d2cef2/README.md#container):
+- [`container`](https://github.com/testing-library/react-testing-library/blob/fd2df8d18652786a95bce34741180137f9d2cef2/README.md#container):
   The `div` your component was rendered to
-- [`unmount`](https://github.com/kentcdodds/react-testing-library/blob/fd2df8d18652786a95bce34741180137f9d2cef2/README.md#unmount):
+- [`unmount`](https://github.com/testing-library/react-testing-library/blob/fd2df8d18652786a95bce34741180137f9d2cef2/README.md#unmount):
   A simple wrapper over `ReactDOM.unmountComponentAtNode`to unmount your
   component (to facilitate easier testing of `componentWillUnmount` for
   example).
-- [`getByLabelText`](https://github.com/kentcdodds/react-testing-library/blob/fd2df8d18652786a95bce34741180137f9d2cef2/README.md#getbylabeltexttext-textmatch-options-selector-string---htmlelement):
+- [`getByLabelText`](https://github.com/testing-library/react-testing-library/blob/fd2df8d18652786a95bce34741180137f9d2cef2/README.md#getbylabeltexttext-textmatch-options-selector-string---htmlelement):
   Get a form control associated to a label
-- [`getByPlaceholderText`](https://github.com/kentcdodds/react-testing-library/blob/fd2df8d18652786a95bce34741180137f9d2cef2/README.md#getbyplaceholdertexttext-textmatch-htmlelement):
+- [`getByPlaceholderText`](https://github.com/testing-library/react-testing-library/blob/fd2df8d18652786a95bce34741180137f9d2cef2/README.md#getbyplaceholdertexttext-textmatch-htmlelement):
   Placeholders aren't proper alternatives to labels, but if this makes more
   sense for your use case it's available.
-- [`getByText`](https://github.com/kentcdodds/react-testing-library/blob/fd2df8d18652786a95bce34741180137f9d2cef2/README.md#getbytexttext-textmatch-htmlelement):
+- [`getByText`](https://github.com/testing-library/react-testing-library/blob/fd2df8d18652786a95bce34741180137f9d2cef2/README.md#getbytexttext-textmatch-htmlelement):
   Get any element by its text content.
-- [`getByAltText`](https://github.com/kentcdodds/react-testing-library/blob/fd2df8d18652786a95bce34741180137f9d2cef2/README.md#getbyalttexttext-textmatch-htmlelement):
+- [`getByAltText`](https://github.com/testing-library/react-testing-library/blob/fd2df8d18652786a95bce34741180137f9d2cef2/README.md#getbyalttexttext-textmatch-htmlelement):
   Get an element (like an `<img`) by it's `alt` attribute value.
-- [`getByTestId`](https://github.com/kentcdodds/react-testing-library/blob/fd2df8d18652786a95bce34741180137f9d2cef2/README.md#getbytestidtext-textmatch-htmlelement):
+- [`getByTestId`](https://github.com/testing-library/react-testing-library/blob/fd2df8d18652786a95bce34741180137f9d2cef2/README.md#getbytestidtext-textmatch-htmlelement):
   Get an element by its `data-testid` attribute.
 
 Each of those `get*` utilities will throw a useful error message if no element
@@ -239,9 +239,9 @@ Also, for these `get*` utilities, to find a matching element, you can pass:
 Thanks to [Anto Aravinth Belgin Rayen](https://github.com/antoaravinth), we have
 some handy custom Jest matchers as well:
 
-- [`toBeInTheDOM`](https://github.com/kentcdodds/react-testing-library/blob/fd2df8d18652786a95bce34741180137f9d2cef2/README.md#tobeinthedom):
+- [`toBeInTheDOM`](https://github.com/testing-library/react-testing-library/blob/fd2df8d18652786a95bce34741180137f9d2cef2/README.md#tobeinthedom):
   Assert whether an element present in the DOM or not.
-- [`toHaveTextContent`](https://github.com/kentcdodds/react-testing-library/blob/fd2df8d18652786a95bce34741180137f9d2cef2/README.md#tohavetextcontent):
+- [`toHaveTextContent`](https://github.com/testing-library/react-testing-library/blob/fd2df8d18652786a95bce34741180137f9d2cef2/README.md#tohavetextcontent):
   Check whether the given element has a text content or not.
 
 > Note: now these have been extracted to
@@ -253,8 +253,8 @@ some handy custom Jest matchers as well:
 A big feature of this library is that it doesn't have utilities that enable
 testing implementation details. It focuses on providing utilities that encourage
 good testing and software practices. I hope that by using
-[the](https://github.com/kentcdodds/react-testing-library)
-[`react-testing-library`](https://github.com/kentcdodds/react-testing-library)your
+[the](https://github.com/testing-library/react-testing-library)
+[`react-testing-library`](https://github.com/testing-library/react-testing-library)your
 React testbases are easier to understand and maintain.
 
 **Learn more about Testing from me**:

--- a/content/blog/introducing-the-react-testing-library/index.md
+++ b/content/blog/introducing-the-react-testing-library/index.md
@@ -245,7 +245,7 @@ some handy custom Jest matchers as well:
   Check whether the given element has a text content or not.
 
 > Note: now these have been extracted to
-> [jest-dom](https://github.com/gnapse/jest-dom) which is maintained by
+> [jest-dom](https://github.com/testing-library/jest-dom) which is maintained by
 > [Ernesto García](https://github.com/gnapse)
 
 ### Conclusion

--- a/content/blog/javascript-default-parameters/index.md
+++ b/content/blog/javascript-default-parameters/index.md
@@ -117,8 +117,8 @@ Good luck!
 - [More than you want to know about ES6 Modules @ Learn to Code Websites and Apps Meetup (remote)](https://www.youtube.com/watch?v=kTlcu16rSLc&list=PLV5CVI1eNcJgNqzNwcs4UKrlJdhfDjshf)
 - [ES6 and Beyond Workshop Part 1 at PayPal (Jan 2017)](https://www.youtube.com/watch?v=t3R3R7UyN2Y&list=PLV5CVI1eNcJgNqzNwcs4UKrlJdhfDjshf)
 - [ES6 and Beyond Workshop Part 2 at PayPal (March 2017)](https://www.youtube.com/watch?v=eOKQDh50ECU&list=PLV5CVI1eNcJgNqzNwcs4UKrlJdhfDjshf)
-- [Code Transformation and Linting](https://kentcdodds.com/workshops/#code-transformation-and-linting)
-- [Writing custom Babel and ESLint plugins with ASTs](https://kentcdodds.com/talks/#writing-custom-babel-and-eslint-plugins-with-asts)
+- [Code Transformation and Linting](/workshops/#code-transformation-and-linting)
+- [Writing custom Babel and ESLint plugins with ASTs](/talks/#writing-custom-babel-and-eslint-plugins-with-asts)
 
 Also, don't forget to subscribe to [my youtube channel](http://kcd.im/youtube)
 for my daily devtips, like

--- a/content/blog/making-your-ui-tests-resilient-to-change/index.md
+++ b/content/blog/making-your-ui-tests-resilient-to-change/index.md
@@ -203,7 +203,7 @@ I hope this is helpful to you. Good luck! Enjoy :)
   about something I think is really important to remember.
 - [Testing JavaScript Applications](https://frontendmasters.com/courses/testing-javascript/) — my
   testing workshop on Frontend Masters.
-  ([Resources and practice run here](https://kentcdodds.com/workshops/#testing-javascript-applications)).
+  ([Resources and practice run here](/workshops/#testing-javascript-applications)).
 - [How Node.js require() works](https://twitter.com/NTulswani/status/916961093280456705) — a
   tweet from my friend [Nitin Tulswani](https://twitter.com/NTulswani) that
   explains briefly what happens when you use the require function.

--- a/content/blog/migrating-to-reacts-new-context-api/index.md
+++ b/content/blog/migrating-to-reacts-new-context-api/index.md
@@ -16,8 +16,8 @@ With
 [the recent release of React 16.3.0](https://reactjs.org/blog/2018/03/29/react-v-16-3.html)
 came an official context API. You can learn more about the why and how behind
 this API from my previous blog post:
-["React's ⚛️ new Context API"](https://kentcdodds.com/blog/reacts-new-context-api).
-Because of this significant change, I'm making an update to
+["React's ⚛️ new Context API"](/blog/reacts-new-context-api). Because of this
+significant change, I'm making an update to
 [my advanced component patterns course on egghead.io](https://egghead.io/courses/advanced-react-component-patterns)
 to use the new API rather than the old one. As I've been working on updating the
 course, I've been migrating from the old context API to the new one and I

--- a/content/blog/polyfill-as-needed-with-polyfill-service/index.md
+++ b/content/blog/polyfill-as-needed-with-polyfill-service/index.md
@@ -15,9 +15,8 @@ bannerCredit:
   [Unsplash](https://unsplash.com/search/photos/service-bridge)'
 ---
 
-In last week's newsletter
-["What is a polyfill"](https://blog.kentcdodds.com/what-is-a-polyfill-acab87e8481e),
-I talked about a situation I came across with a white screen on IE10 (the app
+In last week's newsletter ["What is a polyfill"](/blog/what-is-a-polyfill), I
+talked about a situation I came across with a white screen on IE10 (the app
 crashed because we were missing polyfills). I explained a bit of the difference
 between a polyfill and a code transform. I explained a few options you have at
 your disposal to use new JavaScript features and still support older browsers.
@@ -188,8 +187,8 @@ Pretty cool!
 - [More than you want to know about ES6 Modules @ Learn to Code Websites and Apps Meetup (remote)](https://www.youtube.com/watch?v=kTlcu16rSLc&list=PLV5CVI1eNcJgNqzNwcs4UKrlJdhfDjshf)
 - [ES6 and Beyond Workshop Part 1 at PayPal (Jan 2017)](https://www.youtube.com/watch?v=t3R3R7UyN2Y&list=PLV5CVI1eNcJgNqzNwcs4UKrlJdhfDjshf)
 - [ES6 and Beyond Workshop Part 2 at PayPal (March 2017)](https://www.youtube.com/watch?v=eOKQDh50ECU&list=PLV5CVI1eNcJgNqzNwcs4UKrlJdhfDjshf)
-- [Code Transformation and Linting](https://kentcdodds.com/workshops/#code-transformation-and-linting)
-- [Writing custom Babel and ESLint plugins with ASTs](https://kentcdodds.com/talks/#writing-custom-babel-and-eslint-plugins-with-asts)
+- [Code Transformation and Linting](/workshops/#code-transformation-and-linting)
+- [Writing custom Babel and ESLint plugins with ASTs](/talks/#writing-custom-babel-and-eslint-plugins-with-asts)
 
 Also, don't forget to subscribe to [my youtube channel](http://kcd.im/youtube)
 for my daily devtips, like

--- a/content/blog/react-hooks-whats-going-to-happen-to-my-tests/index.md
+++ b/content/blog/react-hooks-whats-going-to-happen-to-my-tests/index.md
@@ -333,7 +333,7 @@ function Counter(props) {
 
 Cool, and because we wrote our test the way we did, it's actually still passing.
 Woo! BUT! As we learned from
-"[React Hooks: What's going to happen to render props?](https://blog.kentcdodds.com/8ade1f00f159)"
+"[React Hooks: What's going to happen to render props?](/blog/react-hooks-whats-going-to-happen-to-render-props)"
 custom hooks are a better primitive for code sharing in React. So let's rewrite
 this to a custom hook:
 

--- a/content/blog/react-hooks-whats-going-to-happen-to-react-context/index.md
+++ b/content/blog/react-hooks-whats-going-to-happen-to-react-context/index.md
@@ -18,8 +18,8 @@ bannerCredit:
 ---
 
 Earlier this year, the React team introduced the first official context API.
-[I blogged about that new API](https://kentcdodds.com/blog/reacts-new-context-api)
-and people got sufficiently and reasonably hyped.
+[I blogged about that new API](/blog/reacts-new-context-api) and people got
+sufficiently and reasonably hyped.
 
 One common complaint that I knew people were going to have when applying it
 practically was the fact that the context consumer is a render-prop based API.

--- a/content/blog/react-hooks-whats-going-to-happen-to-render-props/index.md
+++ b/content/blog/react-hooks-whats-going-to-happen-to-render-props/index.md
@@ -25,7 +25,7 @@ About a year ago, I published
 In that post, I show the entire implementation (at the time) of
 [`react-toggled`](https://github.com/kentcdodds/react-toggled) which I actually
 built for the sole purpose of teaching some of the patterns that I used in
-[`downshift`](https://github.com/paypal/downshift). It's a much smaller and
+[`downshift`](https://github.com/downshift-js/downshift). It's a much smaller and
 simpler component that implements many of the same patterns as downshift so it
 served as a great way to teach the prop getters pattern.
 
@@ -174,7 +174,7 @@ using hooks. Is there any reason to continue writing or using components that
 expose a render props API?
 
 YES! Observe! Here's
-[an example of using downshift with react-virtualized](https://github.com/paypal/downshift/blob/9b3467dce2be59832765277570857de5679d8392/stories/examples/windowing-with-react-virtualized.js).
+[an example of using downshift with react-virtualized](https://github.com/downshift-js/downshift/blob/9b3467dce2be59832765277570857de5679d8392/stories/examples/windowing-with-react-virtualized.js).
 Here's the relevant bit:
 
 ```jsx

--- a/content/blog/react-jsx-as-a-server-side-templating-language/index.md
+++ b/content/blog/react-jsx-as-a-server-side-templating-language/index.md
@@ -64,17 +64,16 @@ of the gotchas and solutions that I ran into while making this transition.
 
 This was actually as easy as `npm install --save react react-dom` in the
 `server`. Because [paypal.me](http://paypal.me/) uses
-[paypal-scripts](https://blog.kentcdodds.com/automation-without-config-412ab5e47229),
-the server's already compiled with the built-in babel configuration which will
-automatically add the necessary react plugins if the project lists react as a
-dep. Nice! I LOVE Toolkits!
+[paypal-scripts](/blog/tools-without-config), the server's already compiled with
+the built-in babel configuration which will automatically add the necessary
+react plugins if the project lists react as a dep. Nice! I LOVE Toolkits!
 
 ### HTML Structure
 
 The biggest challenge I faced with this involves integration with other PayPal
 modules that generate HTML that need to be inserted into the HTML that we're
 rendering. One such example of this is our polyfill service that
-[I wrote about a while back](https://blog.kentcdodds.com/polyfill-as-needed-with-polyfill-service-35f0ff306a26)which
+[I wrote about a while back](/blog/polyfill-as-needed-with-polyfill-service)which
 inserts a script tag that has some special query params and
 [a server nonce](https://en.wikipedia.org/wiki/Cryptographic_nonce). We have
 this as middleware and it adds a `res.locals.polyfill.headHTML` which is a

--- a/content/blog/reacts-new-context-api/index.md
+++ b/content/blog/reacts-new-context-api/index.md
@@ -17,7 +17,7 @@ bannerCredit:
 
 > Curious about what's going to happen to the context API when
 > [React hooks](https://reactjs.org/hooks) are stable? Read all about it here:
-> [https://blog.kentcdodds.com/react-hooks-whats-going-to-happen-to-react-context-1881f8a058be](https://blog.kentcdodds.com/react-hooks-whats-going-to-happen-to-react-context-1881f8a058be)
+> [https://kentcdodds.com/blog/react-hooks-whats-going-to-happen-to-react-context](/blog/react-hooks-whats-going-to-happen-to-react-context)
 
 Have you heard of the context API in React? If you've heard of it, are you like
 many others afraid to use it directly because you saw this in the official docs:

--- a/content/blog/solidifying-what-you-learn/index.md
+++ b/content/blog/solidifying-what-you-learn/index.md
@@ -50,16 +50,16 @@ learn from. The content will now be used to give two distinct workshops (both of
 which I'll be giving for [Frontend Masters](https://frontendmasters.com/) and
 [Workshop.me](https://workshop.me/?a=kent)):
 
-- [Testing Practices and Principles](https://kentcdodds.com/workshops/#testing-practices-and-principles)
-- [Testing React and Web Applications](https://kentcdodds.com/workshops/#testing-react-and-web-applications)
+- [Testing Practices and Principles](/workshops/#testing-practices-and-principles)
+- [Testing React and Web Applications](/workshops/#testing-react-and-web-applications)
 
 The process of updating the content for this and splitting one workshop into two
 has been interesting for me. Being able to iterate and make content better is
 cool. After you've given the same content over and over, you learn how to
 deliver it better. For example, I've given my
-[ES6 and Beyond workshop](https://kentcdodds.com/workshops/#es6-and-beyond) six
-times now, so I feel pretty great about how to help people understand what I'm
-trying to communicate and avoid distractions (come to Salt Lake for
+[ES6 and Beyond workshop](/workshops/#es6-and-beyond) six times now, so I feel
+pretty great about how to help people understand what I'm trying to communicate
+and avoid distractions (come to Salt Lake for
 [my next presentation of it!](https://workshop.me/2018-07-es6?a=kent))
 
 An awesome side-effect of this iteration is the impact it has on me and my
@@ -103,9 +103,8 @@ Good luck!
 
 **Things to not miss**:
 
-- I updated my [workshops](https://kentcdodds.com/workshops) and
-  [talks](https://kentcdodds.com/talks) pages on my website to list the talks
-  and workshops I'm scheduled to give this year so far.
+- I updated my [workshops](/workshops) and [talks](/talks) pages on my website
+  to list the talks and workshops I'm scheduled to give this year so far.
 - [Top React Blogs, Newsletters, and Online Communities](https://blog.instabug.com/2018/02/react-blogs/) — some
   handy resources here!
 - Thinking hard about what to put here and came up dry this week! Also, I'm

--- a/content/blog/spelunking-in-node-modules/index.md
+++ b/content/blog/spelunking-in-node-modules/index.md
@@ -35,7 +35,7 @@ also `react`, and that's when the trouble started. `downshift`has several tests
 for error cases (errors thrown when validating how you interact with the prop
 getters for example). It has some assertions that an error is thrown when doing
 something wrong when trying to mount downshift.
-[This test](https://github.com/paypal/downshift/blob/702e7b037c27519dae97fa21f5a2aecc649027dd/src/__tests__/downshift.get-label-props.js#L35-L41)
+[This test](https://github.com/downshift-js/downshift/blob/702e7b037c27519dae97fa21f5a2aecc649027dd/src/__tests__/downshift.get-label-props.js#L35-L41)
 in particular resulted in this output:
 
 ```
@@ -59,7 +59,7 @@ Error: Uncaught [Error: downshift: You provided the id of "foo" for your input, 
 
 The funny thing about this though is that the tests all still passed! In
 addition, those logs are coming from a `console.error` call, and
-[the top of that file](https://github.com/paypal/downshift/blob/702e7b037c27519dae97fa21f5a2aecc649027dd/src/__tests__/downshift.get-label-props.js#L5-L12)
+[the top of that file](https://github.com/downshift-js/downshift/blob/702e7b037c27519dae97fa21f5a2aecc649027dd/src/__tests__/downshift.get-label-props.js#L5-L12)
 is mocking `console.error` to make it not log anything at all!
 
 ```js
@@ -101,7 +101,7 @@ files? Check this out. Run the following commands and you'll get a report of the
 code on the `node_modules` directory in the `downshift` project:
 
 ```
-git clone https://github.com/paypal/downshift.git
+git clone https://github.com/downshift-js/downshift.git
 cd downshift
 npm install
 npx cloc ./node_modules

--- a/content/blog/super-simple-start-to-serverless/index.md
+++ b/content/blog/super-simple-start-to-serverless/index.md
@@ -21,7 +21,7 @@ bannerCredit:
 
 This last little while I've been doing a fair amount of work on
 [kentcdodds.com](https://kentcdodds.com). One page that I've been working on is
-the [contact page](https://kentcdodds.com/contact) where you can
+the [contact page](/contact) where you can
 [request enterprise training](https://kcd.im/request-a-workshop),
 [schedule an hour of my time for consulting](https://kcd.im/consulting), or even
 [leave your own testimonial of my work](https://kcd.im/testimonial) (I'd love it

--- a/content/blog/test-isolation-with-react/index.md
+++ b/content/blog/test-isolation-with-react/index.md
@@ -360,8 +360,8 @@ and you'll have a much better time testing! Good luck!
 
 - [Byteconf React Speakers: Round One](https://medium.com/byteconf/byteconf-react-speakers-round-one-ab25af8edf23) — Look!
   It's a free online conference and I'm speaking at it!
-- [🏎 downshift 2.0.0 released 🎉](https://blog.kentcdodds.com/downshift-2-released-26b49589e8d2) — Even
-  better accessibility, React Native and ReasonReact support, even simpler API,
+- [🏎 downshift 2.0.0 released 🎉](/blog/downshift-2-0-0-released) — Even better
+  accessibility, React Native and ReasonReact support, even simpler API,
   improved docs, new examples site, Flow and TypeScript support, and a new
   online community ⚛️
 - [keycode.info](http://keycode.info/) by

--- a/content/blog/testing-components-using-render-props/index.md
+++ b/content/blog/testing-components-using-render-props/index.md
@@ -106,16 +106,15 @@ implementation details a little more.
 ![UI, Service, Unit](./images/0.png)
 
 > _Sorry, no example of E2E tests today. Maybe when I publish this to_ >
-> [_my blog_](https://blog.kentcdodds.com/) _I'll have some..._
+> [_my blog_](/blog) _I'll have some..._
 
 ### Integration Tests
 
-That said,
-[I suggest focusing on integration tests](https://blog.kentcdodds.com/write-tests-not-too-many-mostly-integration-5e8c7fff591c).
-With an integration test, you likewise don't have to change too much about how
-you test the component. Here are the integration tests from the repo. You'll
-notice that there's no indication that the `FruitAutocomplete` component is
-implemented with a render prop component (an implementation detail):
+That said, [I suggest focusing on integration tests](/blog/write-tests). With an
+integration test, you likewise don't have to change too much about how you test
+the component. Here are the integration tests from the repo. You'll notice that
+there's no indication that the `FruitAutocomplete` component is implemented with
+a render prop component (an implementation detail):
 
 ```jsx
 import React from 'react'
@@ -298,10 +297,10 @@ I hope this is helpful to you! Good luck!
 - [Learn, Build, and Teach with Kent C. Dodds](http://itcareerenergizer.com/e35/)
   on [I.T. Career Energizer](http://itcareerenergizer.com/) — You can find my
   other appearances on podcasts and things on
-  [my website appearances page](https://kentcdodds.com/appearances/) 🎙
+  [my website appearances page](/appearances) 🎙
 - [ReactJS RFCs repo](https://github.com/reactjs/rfcs) — RFCs for changes to
   React. Check it out. It already has a few very interesting pull requests.
-- [Learn React Fundamentals 🆓 and Advanced Patterns ⚛️ 🎁](https://blog.kentcdodds.com/learn-react-fundamentals-and-advanced-patterns-eac90341c9db) — If
+- [Learn React Fundamentals 🆓 and Advanced Patterns ⚛️ 🎁](/blog/learn-react-fundamentals-and-advanced-patterns) — If
   you've missed this, then you've either just started following me or you
   haven't been paying attention 😅
 - [React 🎄](https://react.holiday/) — "This is a React advent thingy; the whole

--- a/content/blog/testing-implementation-details/index.md
+++ b/content/blog/testing-implementation-details/index.md
@@ -17,14 +17,14 @@ bannerCredit:
 ---
 
 Last year when I was using enzyme (like everyone else at the time), I stepped
-carefully around certain APIs in enzyme. I
-[completely avoided shallow rendering](https://blog.kentcdodds.com/why-i-never-use-shallow-rendering-c08851a68bb7),
-_never_ used APIs like `instance()`, `state()`, or `find('ComponentName')`. And
-in code reviews of other people's pull requests I explained again and again why
-it's important to avoid these APIs. The reason is they each allow your test to
-test implementation details of your components. People often ask me what I mean
-by "implementation details." I mean, it's hard enough to test as it is! Why do
-we have to make all these rules to make it harder?
+carefully around certain APIs in enzyme. I [completely avoided shallow
+rendering](/blog/why-i-never-use-shallow-rendering, _never_ used APIs like
+`instance()`, `state()`, or `find('ComponentName')`. And in code reviews of
+other people's pull requests I explained again and again why it's important to
+avoid these APIs. The reason is they each allow your test to test implementation
+details of your components. People often ask me what I mean by "implementation
+details." I mean, it's hard enough to test as it is! Why do we have to make all
+these rules to make it harder?
 
 ### Why is testing implementation details bad?
 
@@ -370,9 +370,9 @@ ever}
   gives a fine Developer Experience (DX) and a single dev dependency for all
   your javascript and css/sass/scss bundling.*
 - [Lessons from Java for testing in React](https://www.vidyasource.com/blog/2018/10/21/lessons-from-java-for-testing-in-react/) — Really
-  interesting take on my
-  [shallow rendering](https://blog.kentcdodds.com/why-i-never-use-shallow-rendering-c08851a68bb7)
-  blog post that has a number of great gems.
+  interesting take on my [shallow
+  rendering](/blog/why-i-never-use-shallow-rendering blog post that has a number
+  of great gems.
 - ["A brief analysis and comparison of the CSS for Twitter's PWA vs Twitter's legacy desktop website. The difference is dramatic and I'll touch on some reasons why."](https://twitter.com/necolas/status/1058949372837122048)
   (A very interesting thread by [@necolas](https://twitter.com/necolas) I
   recommend you give a read).

--- a/content/blog/testing-implementation-details/index.md
+++ b/content/blog/testing-implementation-details/index.md
@@ -235,7 +235,7 @@ it would! And guess what, we DO have such a tool!
 
 So we could rewrite all these tests with enzyme, limiting ourselves to APIs that
 are free of implementation details, but instead, I'm just going to use
-[react-testing-library](https://github.com/kentcdodds/react-testing-library)
+[react-testing-library](https://github.com/testing-library/react-testing-library)
 which will make it very difficult to include implementation details in my tests.
 Let's check that out now!
 
@@ -296,7 +296,7 @@ component. So our test should typically only see/interact with the props that
 are passed, and the rendered output.
 
 This is precisely what the
-[react-testing-library](https://github.com/kentcdodds/react-testing-library)
+[react-testing-library](https://github.com/testing-library/react-testing-library)
 test does. It passes fake props to the Accordion, then it interacts with the
 rendered output by querying the output for the contents that will be displayed
 to the user (or ensuring that it wont be displayed) and clicking the buttons
@@ -322,7 +322,7 @@ that the application code works for the production users._
 Oh, and [React Hooks](https://reactjs.org/hooks) got you all excited? If you
 rewrite that accordion component to use React hooks, the enzyme test fails
 terribly, while the
-[react-testing-library](https://github.com/kentcdodds/react-testing-library)
+[react-testing-library](https://github.com/testing-library/react-testing-library)
 test continues to work.
 
 ![happy goats](./images/0.gif)

--- a/content/blog/the-beginners-guide-to-reactjs/index.md
+++ b/content/blog/the-beginners-guide-to-reactjs/index.md
@@ -14,7 +14,7 @@ bannerCredit:
 
 Yesterday my two new ReactJS courses were published on
 [egghead.io](http://egghead.io/).
-[Read more about them here](https://blog.kentcdodds.com/learn-react-fundamentals-and-advanced-patterns-eac90341c9db).
+[Read more about them here](/blog/learn-react-fundamentals-and-advanced-patterns).
 I had high hopes for this release, but the response has been way more positive
 than I had expected. The announcement post got in
 [Medium's top 20 posts yesterday](https://medium.com/browse/top/december-04-2017)
@@ -25,7 +25,7 @@ yet, give them a look! If you have, I hope you loved them!
 
 Two weeks ago, my newsletter was an overview of the
 [Advanced React Component Patterns course](https://egghead.io/courses/advanced-react-component-patterns)
-([that's been published today](https://blog.kentcdodds.com/56af2b74bc5f)!) This
+([that's been published today](/blog/advanced-react-component-patterns)!) This
 week I'd like to talk a little bit about the other course that was published:
 [The Beginner's Guide to ReactJS](https://egghead.io/courses/the-beginner-s-guide-to-reactjs).
 
@@ -73,7 +73,7 @@ will be helpful to you as well). Good luck!
 - [Why Funding Open Source is Hard](https://medium.com/@codesponsor/why-funding-open-source-is-hard-652b7055569d) — Alternate
   title: "Why Code Sponsor is shutting down after raising \$10k for OSS
   developers in 4 months").
-- [Learn React Fundamentals and Advanced Patterns](https://blog.kentcdodds.com/learn-react-fundamentals-and-advanced-patterns-eac90341c9db) — I'm
+- [Learn React Fundamentals and Advanced Patterns](/blog/learn-react-fundamentals-and-advanced-patterns) — I'm
   just pretty excited about the course release!
 - [egghead.io Sale](https://egghead.io/gifts) — Save 30% on a year subscription!
 - [`ReactPrimer`](https://github.com/ReactPrimer/ReactPrimer) - React component

--- a/content/blog/the-state-reducer-pattern/index.md
+++ b/content/blog/the-state-reducer-pattern/index.md
@@ -20,9 +20,9 @@ bannerCredit:
 
 This last week, [@notruth](https://github.com/notruth) (new code contributor to
 the
-[downshift](https://github.com/paypal/downshift/blob/master/README.md#contributors)
+[downshift](https://github.com/downshift-js/downshift/blob/master/README.md#contributors)
 project), filed an issue:
-["closeOnSelection" property (Multiple selection out of box)](https://github.com/paypal/downshift/issues/319).
+["closeOnSelection" property (Multiple selection out of box)](https://github.com/downshift-js/downshift/issues/319).
 All you really need to know about that issue is that the decisions made about
 how downshift updates its state based on user interaction in certain scenarios
 didn't agree with what @notruth wants for their implementation. 😖
@@ -60,7 +60,7 @@ user selects an item and in the issue @notruth posted, they are saying that
 decision doesn't fit their use case. 🤷‍♂️
 
 This is one reason why downshift supports
-[control props](https://github.com/paypal/downshift#control-props). It allows
+[control props](https://github.com/downshift-js/downshift#control-props). It allows
 you to have complete control over the internal state of downshift. In this case,
 @notruth could have controlled the `isOpen` state and use the `onStateChange` to
 know when to update their version of that state. However, that's a fair amount
@@ -73,11 +73,11 @@ boilerplate further. 😈
 ### A simpler API
 
 That's when I came up with
-[a new prop I initially called](https://github.com/paypal/downshift/issues/319#issuecomment-361640218)
-[`modifyStateChange`](https://github.com/paypal/downshift/issues/319#issuecomment-361640218).
+[a new prop I initially called](https://github.com/downshift-js/downshift/issues/319#issuecomment-361640218)
+[`modifyStateChange`](https://github.com/downshift-js/downshift/issues/319#issuecomment-361640218).
 Because downshift already supports control props, it isolates state changes to
 an internal method called
-[`internalSetState`](https://github.com/paypal/downshift/blob/118a87234a9331e716142acfb95eb411cc4f8015/src/downshift.js#L302-L410).
+[`internalSetState`](https://github.com/downshift-js/downshift/blob/118a87234a9331e716142acfb95eb411cc4f8015/src/downshift.js#L302-L410).
 It's a surprisingly long method (mostly because it's highly commented). This
 isolation made the implementation of this new feature trivial. Any time we make
 state changes, we first call a method to see if the user of downshift is
@@ -90,12 +90,12 @@ want to prevent `isOpen` from changing to `false` if the user selects
 (keydown/click) on an item. So they need to know what type of change is about to
 happen. Luckily, we needed this distinction for `onStateChange` as well and
 already had this mechanism in place! It's called
-[`stateChangeTypes`](https://github.com/paypal/downshift#statechangetypes)
-([here's the current list](https://github.com/paypal/downshift/blob/118a87234a9331e716142acfb95eb411cc4f8015/src/downshift.js#L103-L119)).
+[`stateChangeTypes`](https://github.com/downshift-js/downshift#statechangetypes)
+([here's the current list](https://github.com/downshift-js/downshift/blob/118a87234a9331e716142acfb95eb411cc4f8015/src/downshift.js#L103-L119)).
 🤖
 
 So, @notruth opened
-[the pull request](https://github.com/paypal/downshift/pull/320) to add the
+[the pull request](https://github.com/downshift-js/downshift/pull/320) to add the
 `modifyStateChange`. After considering it a little further, I decided that this
 could be generalized into a pattern that could be really useful for other
 libraries. Patterns are much easier to evangelize when they have a name, so

--- a/content/blog/ui-testing-myths/index.md
+++ b/content/blog/ui-testing-myths/index.md
@@ -60,7 +60,7 @@ can get confidence that the registration and login flows are working, and then
 skip those for the rest of your tests so you can significantly speed up the
 tests and reduce the points of failure. When you write tests this way and use
 tools like
-[cypress-testing-library](https://github.com/kentcdodds/cypress-testing-library),
+[cypress-testing-library](https://github.com/testing-library/cypress-testing-library),
 practices like page objects are totally unnecessary, and your tests are easier
 to maintain, more reliable, and run faster. You might even find yourself
 replacing Chrome with Cypress as your development workflow tool (which I show

--- a/content/blog/unit-vs-integration-vs-e2e-tests/index.md
+++ b/content/blog/unit-vs-integration-vs-e2e-tests/index.md
@@ -383,23 +383,23 @@ Good luck!
 
 Here are a few relevant blog posts for you as well:
 
-- [Testing Implementation Details](https://blog.kentcdodds.com/testing-implementation-details-ccb8d269586)
-- [React Hooks: What’s going to happen to my tests?](https://blog.kentcdodds.com/react-hooks-whats-going-to-happen-to-my-tests-df4c2b4d67b7)
-- [Common Testing Mistakes](https://blog.kentcdodds.com/common-testing-mistakes-1a3d2d209f0)
-- [UI Testing Myths](https://blog.kentcdodds.com/ui-testing-myths-dfb5f629f20a)
-- [The Merits of Mocking](https://blog.kentcdodds.com/the-merits-of-mocking-a107fd39b721)
-- [React is an implementation detail](https://blog.kentcdodds.com/react-is-an-implementation-detail-and-course-faq-ee73b028745e)
-- [Eliminate an entire category of bugs with a few simple tools](https://blog.kentcdodds.com/eliminate-an-entire-category-of-bugs-with-a-few-simple-tools-f0dd2aaf4bc9)
-- [Why you’ve been bad about testing](https://blog.kentcdodds.com/why-youve-been-bad-about-testing-e96aed98e4b6)
-- [Demystifying Testing](https://blog.kentcdodds.com/demystifying-testing-21039c883f9e)
-- [Confidently Shipping Code](https://blog.kentcdodds.com/confidently-shipping-code-6139403dfffe)
-- [Why I Never Use Shallow Rendering](https://blog.kentcdodds.com/why-i-never-use-shallow-rendering-c08851a68bb7)
-- [Test Isolation with React](https://blog.kentcdodds.com/test-isolation-with-react-6962d3f13d1f)
-- [But really, what is a JavaScript mock?](https://blog.kentcdodds.com/but-really-what-is-a-javascript-mock-10d060966f7d)
-- [But really, what is a JavaScript test?](https://blog.kentcdodds.com/but-really-what-is-a-javascript-test-46fe5f3fad77)
-- [Effective Snapshot Testing](https://blog.kentcdodds.com/effective-snapshot-testing-e0d1a2c28eca)
-- [Making your UI tests resilient to change](https://blog.kentcdodds.com/making-your-ui-tests-resilient-to-change-d37a6ee37269)
-- [Write tests. Not too many. Mostly integration.](https://blog.kentcdodds.com/write-tests-not-too-many-mostly-integration-5e8c7fff591c)
+- [Testing Implementation Details](/blog/testing-implementation-details)
+- [React Hooks: What’s going to happen to my tests?](/blog/react-hooks-whats-going-to-happen-to-my-tests)
+- [Common Testing Mistakes](/blog/common-testing-mistakes)
+- [UI Testing Myths](/blog/ui-testing-myths)
+- [The Merits of Mocking](/blog/the-merits-of-mocking)
+- [React is an implementation detail](/blog/react-is-an-implementation-detail)
+- [Eliminate an entire category of bugs with a few simple tools](/blog/eliminate-an-entire-category-of-bugs-with-a-few-simple-tools)
+- [Why you’ve been bad about testing](/blog/why-youve-been-bad-about-testing)
+- [Demystifying Testing](/blog/demystifying-testing)
+- [Confidently Shipping Code](/blog/confidently-shipping-code)
+- [Why I Never Use Shallow Rendering](/blog/why-i-never-use-shallow-rendering
+- [Test Isolation with React](/blog/test-isolation-with-react)
+- [But really, what is a JavaScript mock?](/blog/but-really-what-is-a-javascript-mock)
+- [But really, what is a JavaScript test?](/blog/but-really-what-is-a-javascript-test)
+- [Effective Snapshot Testing](/blog/effective-snapshot-testing)
+- [Making your UI tests resilient to change](/blog/making-your-ui-tests-resilient-to-change)
+- [Write tests. Not too many. Mostly integration.](/blog/write-tests)
 
 **Things to not miss**:
 

--- a/content/blog/unpkg-an-open-source-cdn-for-npm/index.md
+++ b/content/blog/unpkg-an-open-source-cdn-for-npm/index.md
@@ -94,9 +94,9 @@ dependencies they like. If two teams happen to be using the same version of
 React (pretty likely), then the user wont have to download that version of react
 more than once. This compounds across the number of teams and projects PayPal
 has. And because I also write and maintain
-[paypal-scripts](https://blog.kentcdodds.com/automation-without-config-412ab5e47229),
-I can build-in a really nice process into paypal-scripts so people can get this
-functionality out of the box. Automatic user experience improvement! Woo!
+[paypal-scripts](/blog/tools-without-config), I can build-in a really nice
+process into paypal-scripts so people can get this functionality out of the box.
+Automatic user experience improvement! Woo!
 
 ### Conclusion
 
@@ -114,8 +114,8 @@ files as well as a version chooser which is pretty awesome:
 - [More than you want to know about ES6 Modules @ Learn to Code Websites and Apps Meetup (remote)](https://www.youtube.com/watch?v=kTlcu16rSLc&list=PLV5CVI1eNcJgNqzNwcs4UKrlJdhfDjshf)
 - [ES6 and Beyond Workshop Part 1 at PayPal (Jan 2017)](https://www.youtube.com/watch?v=t3R3R7UyN2Y&list=PLV5CVI1eNcJgNqzNwcs4UKrlJdhfDjshf)
 - [ES6 and Beyond Workshop Part 2 at PayPal (March 2017)](https://www.youtube.com/watch?v=eOKQDh50ECU&list=PLV5CVI1eNcJgNqzNwcs4UKrlJdhfDjshf)
-- [Code Transformation and Linting](https://kentcdodds.com/workshops/#code-transformation-and-linting)
-- [Writing custom Babel and ESLint plugins with ASTs](https://kentcdodds.com/talks/#writing-custom-babel-and-eslint-plugins-with-asts)
+- [Code Transformation and Linting](/workshops/#code-transformation-and-linting)
+- [Writing custom Babel and ESLint plugins with ASTs](/talks/#writing-custom-babel-and-eslint-plugins-with-asts)
 
 **Things to not miss**:
 

--- a/content/blog/updated-advanced-react-component-patterns/index.md
+++ b/content/blog/updated-advanced-react-component-patterns/index.md
@@ -76,7 +76,7 @@ patterns because those are still very awesome.
 
 We have a few lessons that feature a completely **new pattern that wasn't in the
 original course** that I implemented a while ago in
-[downshift](https://github.com/paypal/downshift) called
+[downshift](https://github.com/downshift-js/downshift) called
 [**the state reducer pattern**](https://blog.kentcdodds.com/the-state-reducer-pattern--b40316cfac57):
 
 [**Implement Component State Reducers**](https://egghead.io/lessons/react-implement-component-state-reducers)

--- a/content/blog/updated-advanced-react-component-patterns/index.md
+++ b/content/blog/updated-advanced-react-component-patterns/index.md
@@ -77,7 +77,7 @@ patterns because those are still very awesome.
 We have a few lessons that feature a completely **new pattern that wasn't in the
 original course** that I implemented a while ago in
 [downshift](https://github.com/downshift-js/downshift) called
-[**the state reducer pattern**](https://blog.kentcdodds.com/the-state-reducer-pattern--b40316cfac57):
+[**the state reducer pattern**](/blog/the-state-reducer-pattern):
 
 [**Implement Component State Reducers**](https://egghead.io/lessons/react-implement-component-state-reducers)
 
@@ -103,10 +103,9 @@ how to effectively use the pattern:
 Last time, we had quite a few lessons about the provider pattern. With the new
 Context API, I was able to show everything in a single lesson because the
 Context API is a built-in implementation of the provider pattern! In this lesson
-I give a demonstration of what
-[Prop Drilling](https://blog.kentcdodds.com/prop-drilling-bb62e02cb691) is and
-how the Provider Pattern can simplify things considerably making your React
-codebase much more manageable.
+I give a demonstration of what [Prop Drilling](/blog/prop-drilling) is and how
+the Provider Pattern can simplify things considerably making your React codebase
+much more manageable.
 
 [**Implement the Provider Pattern with React Context**](https://egghead.io/lessons/react-implement-the-provider-pattern-with-react-context)
 

--- a/content/blog/what-is-a-polyfill/index.md
+++ b/content/blog/what-is-a-polyfill/index.md
@@ -144,7 +144,7 @@ that your browsers don't support.
   used [capybara](https://github.com/teamcapybara/capybara) before you'll
   probably love this util from [Justin Searls](https://twitter.com/searls). If
   you like this, then you'll probably love
-  [cypress-testing-library](https://github.com/kentcdodds/cypress-testing-library).
+  [cypress-testing-library](https://github.com/testing-library/cypress-testing-library).
   In any case,
   [don't reuse your CSS selectors as test selectors](https://blog.kentcdodds.com/making-your-ui-tests-resilient-to-change-d37a6ee37269)!
 - [guppy](https://github.com/joshwcomeau/guppy) — 🐠A friendly application

--- a/content/blog/what-is-a-polyfill/index.md
+++ b/content/blog/what-is-a-polyfill/index.md
@@ -64,7 +64,7 @@ With these, if you
 the `includes` function is not transpiled because it's not a syntax issue, but a
 built-in API one and babel's env preset only includes transforms for syntax
 transformations. You _could_
-[write your own babel plugin](https://kentcdodds.com/talks/#writing-custom-babel-and-eslint-plugins-with-asts)
+[write your own babel plugin](/talks/#writing-custom-babel-and-eslint-plugins-with-asts)
 ([like this](https://astexplorer.net/#/gist/538b72e2af148a14d7c0f5824b431cd6/47a57f42697199d6cfa1d4b1027951ef170a980e))
 to transform the code, but for _some_ APIs it just wouldn't be practical because
 the transformed version would be significantly complex.
@@ -146,7 +146,7 @@ that your browsers don't support.
   you like this, then you'll probably love
   [cypress-testing-library](https://github.com/testing-library/cypress-testing-library).
   In any case,
-  [don't reuse your CSS selectors as test selectors](https://blog.kentcdodds.com/making-your-ui-tests-resilient-to-change-d37a6ee37269)!
+  [don't reuse your CSS selectors as test selectors](/blog/making-your-ui-tests-resilient-to-change)!
 - [guppy](https://github.com/joshwcomeau/guppy) — 🐠A friendly application
   manager and task runner for React.js by
   [Josh Comeau](https://twitter.com/joshwcomeau).

--- a/content/blog/when-to-not-use-render-props/index.md
+++ b/content/blog/when-to-not-use-render-props/index.md
@@ -21,7 +21,7 @@ bannerCredit:
 **UPDATE: If you can use react@16.8.0 then the answer is to rarely use render
 props and almost always use a custom hook. HOOKS ARE ALMOST ALWAYS THE SUPERIOR
 PATTERN.**
-[Read about when you might still use render props](https://kentcdodds.com/blog/react-hooks-whats-going-to-happen-to-render-props)
+[Read about when you might still use render props](/blog/react-hooks-whats-going-to-happen-to-render-props)
 
 ---
 
@@ -29,8 +29,7 @@ PATTERN.**
 > things I do!_ [_patreon.com/kentcdodds_](https://www.patreon.com/kentcdodds)
 
 With all the [tweets](https://twitter.com/kentcdodds/status/957388589171539968),
-[posts](https://blog.kentcdodds.com/answers-to-common-questions-about-render-props-a9f84bb12d5d),
-and
+[posts](/blog/answers-to-common-questions-about-render-props), and
 [training videos](https://egghead.io/lessons/react-use-render-props-with-react)
 I have about the render prop pattern, I get this question a lot: "When should I
 not use the render props pattern?"
@@ -41,13 +40,13 @@ outweighs the cost (or because the thought lords told us to and we didn't stop
 to think about it... but I digress). So when you're considering implementing a
 particular tool, library, or pattern, it's very important to think critically
 about the costs and benefits (just like we should
-[think critically about how we manage state in our apps](https://blog.kentcdodds.com/application-state-management-66de608ccb24)).
-To understand the benefits in this
-[context](https://kentcdodds.com/blog/reacts-new-context-api) (😉), you have to
-understand the problems it solves, how it goes about solving those problems
-(especially when compared to alternatives), and (most importantly) **whether you
-have those problems to begin with**. If you don't have the problem, then you're
-incurring the cost of abstraction without reaping the benefits!
+[think critically about how we manage state in our apps](/blog/application-state-management)).
+To understand the benefits in this [context](/blog/reacts-new-context-api) (😉),
+you have to understand the problems it solves, how it goes about solving those
+problems (especially when compared to alternatives), and (most importantly)
+**whether you have those problems to begin with**. If you don't have the
+problem, then you're incurring the cost of abstraction without reaping the
+benefits!
 
 ### The problem
 
@@ -112,9 +111,9 @@ This is possible because of the power of the render prop pattern.
 
 In combination with HOCs, the Provider pattern can also be really handy, and can
 also be implemented via render props (in fact, that's basically what
-[the new context API](https://kentcdodds.com/blog/reacts-new-context-api) is all
-about). Just for fun one day, I decided to implement a provider and HOC for
-downshift. It didn't take me very much time at all before I had
+[the new context API](/blog/reacts-new-context-api) is all about). Just for fun
+one day, I decided to implement a provider and HOC for downshift. It didn't take
+me very much time at all before I had
 [a working implementation](https://codesandbox.io/s/017n1jqo00)! This example
 highlights one of the reasons I prefer render props over other patterns. With
 render props you don't need to make and name so many useless components! But
@@ -139,13 +138,13 @@ I hope that's helpful to you! Good luck!
 
 **Learn more about Render Props from me**:
 
-- [How to give rendering control to users with prop getters](https://blog.kentcdodds.com/how-to-give-rendering-control-to-users-with-prop-getters-549eaef76acf) — My
+- [How to give rendering control to users with prop getters](/blog/how-to-give-rendering-control-to-users-with-prop-getters) — My
   blog post from a few months back about a pattern that's complementary to
   render props
-- [Testing components using render props](https://blog.kentcdodds.com/testing--components-using-render-props-5623ab1814c) — If
+- [Testing components using render props](/blog/testing-components-using-render-props) — If
   you want to test component A which uses component B, and component B has a
   render prop API, read this.
-- [Answers to common questions about render props](https://blog.kentcdodds.com/answers-to-common-questions-about-render-props-a9f84bb12d5d) — My
+- [Answers to common questions about render props](/blog/answers-to-common-questions-about-render-props) — My
   blog post that is what the title says it is...
 
 **Learn about Advanced React Component Patterns from me**:

--- a/content/blog/why-and-how-i-started-public-speaking/index.md
+++ b/content/blog/why-and-how-i-started-public-speaking/index.md
@@ -126,8 +126,7 @@ So why do I speak at meetups and conferences now?
   family's financial stability
 - Promote the practices and technologies that I enjoy in an effort to increase
   the community around them
-- To
-  [solidify what I'm learning](https://blog.kentcdodds.com/solidifying-what-you-learn-6650258c84be)
+- To [solidify what I'm learning](/blog/solidifying-what-you-learn)
 
 How did I get into public speaking?
 

--- a/content/blog/why-i-never-use-shallow-rendering/index.md
+++ b/content/blog/why-i-never-use-shallow-rendering/index.md
@@ -150,13 +150,12 @@ bit like this:
 
 Look familiar? So all shallow rendering is doing is taking the result of the
 given component's `render` method (which will be a React element (read
-[What is JSX?](https://blog.kentcdodds.com/what-is-jsx-310ab98c463e))) and
-giving us a `wrapper` object with some utilities for traversing this JavaScript
-object. This means it doesn't run lifecycle methods (because we just have the
-React elements to deal with), it doesn't allow you to actually interact with DOM
-elements (because nothing's actually rendered), and it doesn't actually attempt
-to get the react elements that are returned by your custom components (like our
-`Fade` component).
+[What is JSX?](/blog/what-is-jsx))) and giving us a `wrapper` object with some
+utilities for traversing this JavaScript object. This means it doesn't run
+lifecycle methods (because we just have the React elements to deal with), it
+doesn't allow you to actually interact with DOM elements (because nothing's
+actually rendered), and it doesn't actually attempt to get the react elements
+that are returned by your custom components (like our `Fade` component).
 
 ### Why people use shallow rendering
 

--- a/content/blog/why-i-never-use-shallow-rendering/index.md
+++ b/content/blog/why-i-never-use-shallow-rendering/index.md
@@ -22,7 +22,7 @@ figure out how to test React components. I tried
 immediately decided that I would never use it to test my React components. I've
 expressed this feeling on many occasions and get asked on a regular basis why I
 feel the way I do about `shallow` rendering and why
-[`react-testing-library`](https://github.com/kentcdodds/react-testing-library)
+[`react-testing-library`](https://github.com/testing-library/react-testing-library)
 will never support `shallow` rendering.
 
 So finally I'm coming out with it and explaining why I never use shallow
@@ -272,7 +272,7 @@ mocks.
 ### Without shallow rendering
 
 I'm a huge believer of the guiding principle of
-[`react-testing-library`](https://github.com/kentcdodds/react-testing-library):
+[`react-testing-library`](https://github.com/testing-library/react-testing-library):
 
 > [_The more your tests resemble the way your software is used, the more confidence they can give you._](https://twitter.com/kentcdodds/status/977018512689455106)_ — Kent
 > C. Dodds 👋_

--- a/content/blog/why-youve-been-bad-about-testing/index.md
+++ b/content/blog/why-youve-been-bad-about-testing/index.md
@@ -44,7 +44,7 @@ component and your test breaks. 😡 I wouldn't want to write tests either.
 When I got started with testing years ago, I struggled. I struggled hard. I've
 spent countless hours learning, building, and rebuilding tools. I even gave a
 _full hour_ talk called
-["ES6, Webpack, Karma, and Code Coverage"](https://kentcdodds.com/talks/#es6-webpack-karma-and-code-coverage).
+["ES6, Webpack, Karma, and Code Coverage"](/talks/#es6-webpack-karma-and-code-coverage).
 It took a full 60 minutes to explain how to make these tools play nicely
 together. It took dozens more hours behind the scenes to figure out what I
 explain in that talk.

--- a/src/pages/links.mdx
+++ b/src/pages/links.mdx
@@ -15,12 +15,12 @@ Links to some things about me...
 - [Twitter](https://kcd.im/twitter)
 - [GitHub](https://kcd.im/github) - I have a bunch of projects on here :)
 - [npm](https://kcd.im/npm) - My published open source JavaScript modules
-- [Info](https://kentcdodds.com/info) - Bio and Photo
+- [Info](/info) - Bio and Photo
 - [JavaScript Air](https://javascriptair.com/) - A podcast I created (I also
   started [Angular Air](http://angularair.com/))
 - [3 Minutes with Kent](https://kcd.im/3-mins) - A
   [briefs.fm](https://briefs.fm/) podcast I occasionally do
-- [Talks](https://kentcdodds.com/talks) - Talks I've given
+- [Talks](/talks) - Talks I've given
 - [Workshops](https://kcd.im/workshops) - Workshops I've given
 - [egghead.io](https://kcd.im/egghead) - My [egghead.io](https://egghead.io/)
   instructor page

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,9 +1,13 @@
 # no idea why, but the gatsby redirect doesn't always work right
 
-/blog/always-use-memo-your-context-value        /blog/how-to-optimize-your-context-value
-/blog/always-use-memo-your-context-value/       /blog/how-to-optimize-your-context-value
-/blog/moist-programming                         /blog/aha-programming
-/blog/moist-programming/                        /blog/aha-programming
-/aha                                            /blog/aha-programming
-/blog/aha                                       /blog/aha-programming
-/workshops/advanced-react-component-patterns    /advanced-react-patterns
+/blog/always-use-memo-your-context-value                                /blog/how-to-optimize-your-context-value
+/blog/always-use-memo-your-context-value/                               /blog/how-to-optimize-your-context-value
+/blog/moist-programming                                                 /blog/aha-programming
+/blog/moist-programming/                                                /blog/aha-programming
+/aha                                                                    /blog/aha-programming
+/blog/aha                                                               /blog/aha-programming
+/workshops/advanced-react-component-patterns                            /advanced-react-patterns
+
+/blog/the-state-reducer-pattern--b40316cfac57                           /blog/the-state-reducer-pattern
+/blog/testing--components-using-render-props-5623ab1814c                /blog/testing-components-using-render-props
+/blog/react-is-an-implementation-detail-and-course-faq-ee73b028745e     /blog/react-is-an-implementation-detail


### PR DESCRIPTION
- Fix outdated `downshift` links
- Fix outdated `react-testing-library` links
- Fix outdated `jest-dom` links
- Fix outdated `all-contributors` links
- Fix outdated `cypress-testing-library` links
- Fix outdated `dom-testing-library` links
- Fix kentcdodds.com links
- Add following redirects
  - `https://blog.kentcdodds.com/the-state-reducer-pattern--b40316cfac57` -> `/blog/the-state-reducer-pattern`
  - `https://blog.kentcdodds.com/testing--components-using-render-props-5623ab1814c` -> `/blog/testing-components-using-render-props`
  - `https://blog.kentcdodds.com/react-is-an-implementation-detail-and-course-faq-ee73b028745e` -> `/blog/react-is-an-implementation-detail`

The following links doesn't exist anymore:
- https://blog.kentcdodds.com/announcing-something-new-4e68b08da35
- https://blog.kentcdodds.com/did-you-know-3079d5aec43b