### PR TITLE
Add autoFocus and type="search" to input on /search page

### DIFF
--- a/src/screens/search.js
+++ b/src/screens/search.js
@@ -108,6 +108,8 @@ function SearchScreen() {
           onChange={useDebFn(() => setSearch(searchInputRef.current.value), {
             wait: 200,
           })}
+          type="search"
+          autoFocus
         />
       </div>
       <div


### PR DESCRIPTION
Hi Kent,

A small PR to add `autoFocus` and `type="search"` to the `input` on the `/search` page. I think the `autoFocus` would help with UX to be able to immediately type the search query. 👍 
