### PR TITLE
Fix broken link to Why React Hooks talk

### DIFF
--- a/content/workshops/react-hooks/index.mdx
+++ b/content/workshops/react-hooks/index.mdx
@@ -67,5 +67,5 @@ what you need to know to start using them in your applications right away.
 - Attend my [React Fundamentals Workshop](/workshops/react-fundamentals) or have
   the equivalent fundamental experience with React and JavaScript.
 - Watch my talk
-  [Why React Hooks](https://www.youtube.com/watch?v=zWsZcBiwgVE)
+  [Why React Hooks](https://www.youtube.com/watch?v=zWsZcBiwgVE&list=PLV5CVI1eNcJgNqzNwcs4UKrlJdhfDjshf)
   (35 minutes).

--- a/content/workshops/react-hooks/index.mdx
+++ b/content/workshops/react-hooks/index.mdx
@@ -67,5 +67,5 @@ what you need to know to start using them in your applications right away.
 - Attend my [React Fundamentals Workshop](/workshops/react-fundamentals) or have
   the equivalent fundamental experience with React and JavaScript.
 - Watch my talk
-  [Why React Hooks](https://youtu.be/zWsZcBiwgVE&list=PLV5CVI1eNcJgNqzNwcs4UKrlJdhfDjshf)
+  [Why React Hooks](https://www.youtube.com/watch?v=zWsZcBiwgVE)
   (35 minutes).


### PR DESCRIPTION
The current link to the "Why React Hooks" talk is broken and gives a 404.
This fixes the link to https://www.youtube.com/watch?v=zWsZcBiwgVE