### PR TITLE
Remove props destructuring for improved clarity

### DIFF
--- a/content/blog/optimize-react-re-renders/index.md
+++ b/content/blog/optimize-react-re-renders/index.md
@@ -35,8 +35,8 @@ practical application this has for you in your day-to-day apps.
 import React from 'react'
 import ReactDOM from 'react-dom'
 
-function Logger({label}) {
-  console.log(`${label} rendered`)
+function Logger(props) {
+  console.log(`${props.label} rendered`)
   return null // we don't really need to actually render anything...
 }
 
@@ -71,18 +71,18 @@ you do this, wait for later in the blog post for practical recommendations).
 import React from 'react'
 import ReactDOM from 'react-dom'
 
-function Logger({label}) {
-  console.log(`${label} rendered`)
+function Logger(props) {
+  console.log(`${props.label} rendered`)
   return null // we don't really need to actually render anything...
 }
 
-function Counter({logger}) {
+function Counter(props) {
   const [count, setCount] = React.useState(0)
   const increment = () => setCount(c => c + 1)
   return (
     <div>
       <button onClick={increment}>The count is {count}</button>
-      {logger}
+      {props.logger}
     </div>
   )
 }
@@ -226,18 +226,18 @@ Here's the second example again (so you don't have to scroll back up):
 import React from 'react'
 import ReactDOM from 'react-dom'
 
-function Logger({label}) {
-  console.log(`${label} rendered`)
+function Logger(props) {
+  console.log(`${props.label} rendered`)
   return null // we don't really need to actually render anything...
 }
 
-function Counter({logger}) {
+function Counter(props) {
   const [count, setCount] = React.useState(0)
   const increment = () => setCount(c => c + 1)
   return (
     <div>
       <button onClick={increment}>The count is {count}</button>
-      {logger}
+      {props.logger}
     </div>
   )
 }

--- a/content/blog/optimize-react-re-renders/index.md
+++ b/content/blog/optimize-react-re-renders/index.md
@@ -37,7 +37,7 @@ import ReactDOM from 'react-dom'
 
 function Logger(props) {
   console.log(`${props.label} rendered`)
-  return null // we don't really need to actually render anything...
+  return null // what is returned here is irrelevant...
 }
 
 function Counter() {
@@ -73,7 +73,7 @@ import ReactDOM from 'react-dom'
 
 function Logger(props) {
   console.log(`${props.label} rendered`)
-  return null // we don't really need to actually render anything...
+  return null // what is returned here is irrelevant...
 }
 
 function Counter(props) {
@@ -228,7 +228,7 @@ import ReactDOM from 'react-dom'
 
 function Logger(props) {
   console.log(`${props.label} rendered`)
-  return null // we don't really need to actually render anything...
+  return null // what is returned here is irrelevant...
 }
 
 function Counter(props) {


### PR DESCRIPTION
When you are talking about how the props are or are not changing, seeing the word `props` in the code examples, as opposed to the destructured keys of the props object, adds clarity for someone who might be a bit newer to React or ES6.

CodeSandboxes will need to be updated to reflect the changes.
https://codesandbox.io/s/react-codesandbox-g9mt5 
https://codesandbox.io/s/react-codesandbox-o9e9f