### PR TITLE
Fix: text crossing page width in index page

### DIFF
--- a/src/components/blog.js
+++ b/src/components/blog.js
@@ -111,6 +111,7 @@ function Blog({data: {allMdx}, pageContext: {pagination}, subscribeForm}) {
               css={css`
                 margin-top: 10px;
                 overflow-x: auto;
+                width: 100%;
               `}
             >
               {post.excerpt}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -119,6 +119,7 @@ const PostTitle = styled.h3`
 const Description = styled.p`
   margin-bottom: 10px;
   display: inline-block;
+  width: 100%;
 `
 
 export default function Index({data: {allMdx}}) {


### PR DESCRIPTION
There was a issue in homepage. Blog excerpt was exceeding page width. Fixed this by adding width: 100% on the p tag.