### PR TITLE
Update section on automatically calling `Cleanup`

### DIFF
--- a/content/blog/avoid-nesting-when-youre-testing/index.md
+++ b/content/blog/avoid-nesting-when-youre-testing/index.md
@@ -553,10 +553,9 @@ test('example 2', () => {
 })
 ```
 
-> Even better, with React Testing Library, you can import
-> `@testing-library/react/cleanup-after-each` and it'll do this for you
-> automatically. Learn more
-> [in the docs](https://testing-library.com/docs/react-testing-library/setup#cleanup)
+> Even better, with React Testing Library, [`Cleanup`](https://testing-library.com/docs/react-testing-library/api#cleanup) is called after each
+> test automatically by default. Learn more
+> [in the docs](https://testing-library.com/docs/react-testing-library/setup#skipping-auto-cleanup)
 
 In addition, sometimes there are definitely good use cases for `before*`, but
 they're normally matched with a cleanup that's necessary in an `after*`. Like


### PR DESCRIPTION
I noticed this section refers to docs that no longer seem to exists. If I understand correctly, the behavior has changed from "opt-in for automatic cleanup" to "opt-out of automatic cleanup".