### PR TITLE
Fixed date formatting issue with Do (day of month) notation.

### DIFF
--- a/src/components/workshops/header.js
+++ b/src/components/workshops/header.js
@@ -19,7 +19,7 @@ const Discount = ({discount}) => (
       >
         <em>
           early bird ends:{' '}
-          {format(new Date(discount.ends), 'MMM Do, yyyy h:mm a (ZZ)')}!
+          {format(new Date(discount.ends), 'MMM do, yyyy h:mm a (ZZ)')}!
         </em>
       </div>
     )}
@@ -149,7 +149,7 @@ const Header = ({
           <Discount discount={discount} />
           {date ? (
             <div className="date">
-              {format(new Date(startTime), 'MMM Do, yyyy')}
+              {format(new Date(startTime), 'MMM do, yyyy')}
             </div>
           ) : (
             <div className="date">TBA</div>

--- a/src/components/workshops/scheduled-workshop.js
+++ b/src/components/workshops/scheduled-workshop.js
@@ -197,7 +197,7 @@ function ScheduledWorkshop({
         >
           <em>
             early bird ends:{' '}
-            {format(new Date(discount.ends), 'MMM Do, yyyy h:mm a (xx)')}
+            {format(new Date(discount.ends), 'MMM do, yyyy h:mm a (xx)')}
           </em>
         </div>
       )}


### PR DESCRIPTION
On Kent's website there was a date formatting problem. For example on this page where you'll see that the early bird for his workshop in Henderson, NV ends on September 261st: https://kentcdodds.com/workshops/

The date format was "MMM Do, yyyy h:mm a (xx)" or variations of that. The problem was the capital D on the "Do", as this has to be a normal d: "MMM do, yyyy h:mm a (xx)".

I fixed this format on three places in two files.

Thanks to the following date-fns issue I was able to find the cause and fix the bug:
https://github.com/date-fns/date-fns/issues/784

I used the following codesandbox to reproduce and fix the problem:
https://codesandbox.io/s/date-formatting-issue-day-of-month-5mpz6