### PR TITLE
Fix of aria-labelledby attribute in form accessibility post

### DIFF
--- a/content/blog/please-stop-building-inaccessible-forms-and-how-to-fix-them/index.md
+++ b/content/blog/please-stop-building-inaccessible-forms-and-how-to-fix-them/index.md
@@ -62,10 +62,10 @@ personal preference):
 <label for="username">Username</label> <input id="username" />
 ```
 
-## input[aria-labeledby] ➡ label[id]
+## input[aria-labelledby] ➡ label[id]
 
 ```html
-<label id="username">Username</label> <input aria-labeledby="username" />
+<label id="username">Username</label> <input aria-labelledby="username" />
 ```
 
 ## label 🤗 input


### PR DESCRIPTION
The correct name of the attribute is `aria-labelledby` (https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-labelledby_attribute).