### PR TITLE
Remove duplicate squares

### DIFF
--- a/content/blog/dont-sync-state-derive-it/index.md
+++ b/content/blog/dont-sync-state-derive-it/index.md
@@ -246,7 +246,7 @@ function calculateDerivedState(squares) {
   const winner = calculateWinner(squares)
   const nextValue = calculateNextValue(squares)
   const status = calculateStatus(winner, squares, nextValue)
-  return {squares, nextValue, winner, status}
+  return {nextValue, winner, status}
 }
 
 function ticTacToeReducer(state, square) {


### PR DESCRIPTION
looks like `calculateDerivedState` returns `squares` and then it immediately gets overwritten
squares is not "derived state" anyway