### PR TITLE
Fix typo (?) in blog post

### DIFF
--- a/content/blog/making-your-ui-tests-resilient-to-change/index.md
+++ b/content/blog/making-your-ui-tests-resilient-to-change/index.md
@@ -143,7 +143,7 @@ like this:
 
 1. Type a fake email in the input labeled `email`
 2. Type a fake password in the input labeled `password`
-3. Click on the button that `sign in`
+3. Click on the button that has text `sign in`
 
 And that would help to ensure that you are testing your software as closely to
 how it's used as possible. Giving you more value from your test.


### PR DESCRIPTION
Changing from "that `sign in`" to "that has text `sign in`". Not sure if that's the best way to word it but it makes the most sense to me :)