### PR TITLE
The terms "false positive" and "false negative" were reversed

### DIFF
--- a/content/blog/testing-implementation-details/index.md
+++ b/content/blog/testing-implementation-details/index.md
@@ -31,8 +31,8 @@ we have to make all these rules to make it harder?
 There are two distinct reasons that it's important to avoid testing
 implementation details. Tests which test implementation details:
 
-1.  Can break when you refactor application code. **False negatives**
-2.  May not fail when you break application code. **False positives**
+1.  Can break when you refactor application code. **False positives**
+2.  May not fail when you break application code. **False negatives**
 
 Let's take a look at each of these in turn, using the following simple accordion
 component as an example:
@@ -104,7 +104,7 @@ Raise your hand if you've seen (or written) tests like this in your codebase
 
 Ok, now let's take a look at how things break down with these tests...
 
-### False negatives when refactoring
+### False positives when refactoring
 
 A surprising number of people find testing distasteful, especially UI testing.
 Why is this? There are various reasons for it, but one big reason I hear again
@@ -164,7 +164,7 @@ Received:
 Is that test failure warning us of a real problem? Nope! The component still
 works fine.
 
-**This is what's called a false negative.** It means that we got a test failure,
+**This is what's called a false positive (or false alarm).** It means that we got a test failure,
 but it was because of a broken test, not broken app code. I honestly cannot
 think of a more annoying test failure situation. Oh well, let's go ahead and fix
 our test:
@@ -181,10 +181,10 @@ our test:
 ```
 
 The takeaway: Tests which test implementation details can give you a false
-negative when you refactor your code. This leads to brittle and frustrating
+positive when you refactor your code. This leads to brittle and frustrating
 tests that seem to break anytime you so much as look at the code.
 
-### False positives
+### False negatives
 
 Ok, so now let's say your co-worker is working in the Accordion and they see
 this code:
@@ -216,8 +216,8 @@ So what went wrong? Didn't we have a test to verify that the state changes when
 appropriately!? Yes you did! But the problem is that there was no test to verify
 that the button was wired up to `setOpenIndex` correctly.
 
-**This is called a false positive.** It means that we didn't get a test failure,
-but we should have! So how do we cover ourselves to make sure this doesn't
+**This is called a false negative.** It means that we _didn't_ get a test failure,
+but we _should_ have! So how do we cover ourselves to make sure this doesn't
 happen again? We need to add another test to verify clicking the button updates
 the state correctly. And then I need to add a coverage threshold of 100% code
 coverage so we don't make this mistake again. Oh, and I should write a dozen or


### PR DESCRIPTION
I learned a lot from this article, and the examples were spot on — a fantastic treatise on why we should avoid the temptation to test implementation details! The only thing is, I think you have "false positive" and "false negative" mixed up.

It's an easy mistake to make, and I think a lot of programmers [have these terms mixed up](https://stackoverflow.com/questions/43726965/test-failures-false-positive-or-false-negative). But you wouldn't do that! I'm hoping I might persuade you that the opposite terms actually make more sense, so that your article can help _clear up_ this popular misconception rather than perpetuate it. :smile:

I think one of the most helpful ways to keep the terms straight is to substitute "**false alarm**" for "**false positive**". What is it that we are _testing for_, that we want to be _alerted to_ (like an alarm)? What is the condition that it is most important that we _detect_?

- **Medicine**: In the well-known field of medicine, of course, it is the presence of a disease or medical condition that we're tested for. If we're testing whether a person is pregnant, and the test incorrectly says that you _are_ pregnant when you're not, that's a **false alarm** — a **false positive**. If the test says you're *not* pregnant but you are (**false negative**), that's a potentially more dangerous mistake to make.

- **Physical safety alarms**: Alarms such as smoke detectors and CO detectors detect for the presence of a physical danger like smoke or CO. If your smoke alarm goes off in the middle of the night and there is no fire or smoke, that is a pretty annoying **false alarm** = **false positive**, and you're likely to want to remove its 9V battery so it won't wake you up again for no reason. But a false alarm is not nearly as deadly as a **false negative**, where your house burns down because your smoke detector failed to alert you to the presence of a fire.

- **Criminal law**: They're testing for guilt: did the defendant commit the crime? If an innocent person is convicted of a crime, that is a **false positive**, whereas if truly guilty prisoner is acquitted of a crime, that is a **false negative**: the jury _should_ have detected the condition (guilt), but failed to raise the alarm. [[1](https://en.wikipedia.org/wiki/False_positives_and_false_negatives)]

- **Sheepherding**: In "[The Boy Who Cried Wolf](https://en.wikipedia.org/wiki/The_Boy_Who_Cried_Wolf)", the shepherd raised the alarm by calling "Wolf, wolf!" when there was no wolf (**false positive**); he kept giving a **false alarm** until the townsfolk soon stopped believing him. (Just like if you have a flaky or brittle test suite, you may soon grow skeptical of the test failures, having been burned one too many times by failures that were caused by something other than incorrect implementation code.) [[1](https://en.wikipedia.org/wiki/False_positives_and_false_negatives)]

- **Airport security**: They're testing for metal that is dangerous. A **false positive** is when ordinary items such as keys or coins get mistaken for weapons (machine goes "beep" — a **false alarm**). [[2](https://www.mathsisfun.com/data/probability-false-negatives-positives.html)]

- **Quality control**: We're testing for items that have defects. A **false positive** is when a good quality item gets rejected, and a **false negative** is when a poor quality item gets accepted. (A "positive" result means there **_is_** a defect.) [[2](https://www.mathsisfun.com/data/probability-false-negatives-positives.html)]

- **Search tools**: They're looking for a "hit" or a "match" for your search string or parameters. If your search and replace finds a reference to a different method with the same name as the one you're trying to rename, or your DuckDuckGo search finds things unrelated to what you're looking for, or your [forensic tool](https://www.magnetforensics.com/blog/false-positives-forensic-tools/) finds results that aren't what you're actually looking for, those are all **false positives**.

- **Antivirus software**: They're testing for files that contain a virus. A **false positive** is when a normal (innocuous) file is thought to be a virus — a **false alarm**. [[2](https://www.mathsisfun.com/data/probability-false-negatives-positives.html)]

- **Spam filtering**: We're testing whether a message is spammy. If it incorrectly flags a legitimate email from your boss or your mom as spam, that's a **false positive** (a **false alarm**), whereas a spam message that gets to your inbox undetected is a **false negative**.


Similarly in the case of automated tests, to be consistent with the sense of the words in the cases above, wouldn't it make the most sense that the thing we are testing for, the thing that our tests are trying to _detect_, is whether something is _wrong_ with the behavior of the code under test (in other words, a bug/defect)?

Once we're clear on that, the other terms fall easily into place:

- A **false positive** error: The test alerted us that something is broken, even though that is not actually the case — a **false alarm**!
  - The condition "the code is incorrect" does not hold (a **true negative**), but the test failed to realize this condition, falsely concluding a **positive** about the condition.

- A **false negative** error: The test *should* have alerted us that something is broken, but it didn't! Our code was incorrect but the test passed anyway; _no_ alarm was raised.
  - The condition "the code is incorrect" holds (a **true positive**), but the test failed to realize this condition, falsely concluding a **negative** about the condition.

That's my take on this anyway. Let me know if I've missed something in my logic.

---

## Why isn't it the opposite? "Positive" seems like it should mean "good" or "passing".

I can see why people get these confused. It's because the English term "positive" has different meanings and is a bit ambiguous. I think people hear "positive" and they intuitively think "positive" in the sense of a **_good_** or _favorable_ or _satisfactory_ outcome. Because that _is_ one way it can be used. (Just not the way it's used here with "false positive". "Positive" has nothing to do with goodness or badness here and more to do with presence or absence of some neutral condition.)

That's why in the quality control example, [they](https://www.mathsisfun.com/data/probability-false-negatives-positives.html) had to clarify that a "**positive**" result means there is a _defect_ (and should be _rejected_) — and does _not_ mean that the product's quality was deemed satisfactory and should be _accepted_ by the QC (as the "happy" meaning of "positive" might lead us to believe).

So in software testing, it's easy to assume a "**positive**" result must refer to when the tests are passing. If that were the case, then of course a **false positive** _would_ refer to when the tests are passing but shouldn't be. But, to be consistent with the general usage of **false positive**, I think we have to define the "positive" result — that is, the condition we are checking for — as "the software produced an incorrect result or behavior". A **true positive**, then, is when a _failing_ test _correctly_ alerts you that it detected a problem with the code, an incorrect result or behavior.

(I think people make a similar mistake with "positive reinforcement" and "negative reinforcement" ...)

---

I suppose you ***could*** define the "condition" as "the software is working as intended" (just like in quality control, you *could* define the test as testing that the item is _acceptable_, rather than testing for presence of _defects_), but that would be opposite of the way the terms are usually used in every other context, and therefore confusing to those who are used to their conventional meanings.

It would be like defining a constant `True` to equal the value `false`. Or raising exceptions as part of your happy code path instead of only when there is an error. You _could_ do it, but...

Maybe it has to do with how you literally cannot devise an automated test that proves that the software is **correct** and bug-free. The only thing you can practically test for is that it failed some expectation and therefore must be behaving **incorrectly**. But even if it passed all of the tests we could think of, there still might be _some_ way in which it could fail that we _didn't_ think of and thus failed to test for. So really, the only thing we _can_ test for is incorrect behavior, as defined by a finite set of known ways in which it can be incorrect. Maybe that's why the "positive" condition in this case has to be (rather unintuitively) the condition where it behaves **incorrectly**, because that's the only thing we can _actually_ test for?

---

See also:
1. https://en.wikipedia.org/wiki/False_positives_and_false_negatives
2. https://www.mathsisfun.com/data/probability-false-negatives-positives.html
3. [false positive](http://xunitpatterns.com/false%20positive.html) / [false negative](http://xunitpatterns.com/false%20negative.html)
4. https://www.ontestautomation.com/on-false-negatives-and-false-positives/
5. https://narainko.wordpress.com/2012/08/26/understanding-false-positive-and-false-negative/
