### PR TITLE
fix: update church name and link

### DIFF
--- a/src/pages/about.mdx
+++ b/src/pages/about.mdx
@@ -8,14 +8,14 @@ description: All about Kent C. Dodds
 I'm a software engineer and teacher. I was born in 1988 (you can do the math)
 and grew up in Idaho. After graduating High School and serving a 2 year mission
 in the Missouri Independence Mission for
-[The Church of Jesus Christ of Latter-Day Saints](https://lds.org), I went to
+[The Church of Jesus Christ of Latter-day Saints](https://www.churchofjesuschrist.org), I went to
 [BYU](https://byu.edu) where I graduated with both a Bachelor and Master's
 degree in Information Systems with an emphasis on Software Application
 Development.
 
 I've written code for
 [More Good Foundation](https://www.moregoodfoundation.org),
-[The Church of Jesus Christ of Latter-Day Saints](https://lds.org),
+[The Church of Jesus Christ of Latter-day Saints](https://www.churchofjesuschrist.org),
 [USAA](https://www.usaa.com), [Domo](https://domo.com),
 [Parakeet](http://goparakeet.com), [Workfront](https://www.workfront.com),
 [Alianza](https://www.alianza.com), [PayPal](https://www.paypal.com/us/home),


### PR DESCRIPTION
The "d" in "The Church of Jesus Christ of Latter-day Saints" is supposed to be lower case. I also updated the link to point the the Church's new domain.