### PR TITLE
I noticed a small detail on line 367.

### DIFF
--- a/content/blog/react-hooks-whats-going-to-happen-to-my-tests/index.md
+++ b/content/blog/react-hooks-whats-going-to-happen-to-my-tests/index.md
@@ -364,7 +364,7 @@ function useCounter() {
   return {count, increment}
 }
 
-const Counter = ({children, ...props}) => children(useCounter(props))
+const Counter = ({children, ...props}) => children({useCounter, ...props})
 
 export default Counter
 export {useCounter}


### PR DESCRIPTION
It should be `const Counter = ({children, ...props}) => children({useCounter, ...props})`
    not `const Counter = ({children, ...props}) => children(useCounter(props))`, correct?