### PR TITLE
Fix Kent's bouncy head on Chrome

### DIFF
--- a/src/components/header.js
+++ b/src/components/header.js
@@ -92,6 +92,7 @@ function Header({
             activeClassName="none"
             headerColor={headerColor}
             css={{
+              position: 'relative',
               fontFamily: fonts.regular,
               display: 'flex',
               alignItems: 'center',


### PR DESCRIPTION
There is a chrome-only heisenbug that causes Kent's photo in the navbar to to be off-center when you navigate away from the landing page. The issue goes away if you refresh the page, or when you adjust the browser size by a pixel it will bounce into place.

I'm running `Chrome Version 79.0.3945.130 (Official Build) (64-bit)` on `macOS Mojave 10.14.4 (18E226)`.

**Demo**

![bouncy](https://dzwonsemrish7.cloudfront.net/items/360p3x2P1B1R1L0Y303a/Screen%20Recording%202020-01-28%20at%2007.49%20PM.gif)


**After the fix it looks as expected**

![not bounce](https://dzwonsemrish7.cloudfront.net/items/2I1i2N3r3Q3I0O0u1e0y/Screen%20Recording%202020-01-28%20at%2007.55%20PM.gif)

P.S. Thanks for all of your content.