### PR TITLE
Restore RSS feed, with measures to reduce build time

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -170,6 +170,25 @@ module.exports = {
       },
     },
     {
+      resolve: `gatsby-plugin-feed`,
+      options: {
+        feeds: [
+          getBlogFeed({
+            filePathRegex: `//content/blog//`,
+            blogUrl: 'https://kentcdodds.com/blog',
+            output: '/blog/rss.xml',
+            title: 'Kent C. Dodds Blog RSS Feed',
+          }),
+          getBlogFeed({
+            filePathRegex: `//content/writing-blog//`,
+            blogUrl: 'https://kentcdodds.com/writing/blog',
+            output: '/writing/blog/rss.xml',
+            title: `Kent's Writing Blog RSS Feed`,
+          }),
+        ],
+      },
+    },
+    {
       resolve: `gatsby-plugin-typography`,
       options: {
         pathToConfigModule: `src/lib/typography`,
@@ -199,4 +218,109 @@ module.exports = {
     },
     'gatsby-plugin-sitemap',
   ],
+}
+
+function getBlogFeed({filePathRegex, blogUrl, ...overrides}) {
+  return {
+    serialize: ({query: {allMdx}}) => {
+      const stripSlash = slug => (slug.startsWith('/') ? slug.slice(1) : slug)
+      return allMdx.edges.map(edge => {
+        const url = `${siteUrl}/${stripSlash(edge.node.fields.slug)}`
+        // TODO: clean this up... This shouldn't be here and it should be dynamic.
+        const footer = `
+          <div style="width: 100%; margin: 0 auto; max-width: 800px; padding: 40px 40px;">
+            <div style="display: flex;">
+              <div style="padding-right: 20px;">
+                <img
+                  src="https://kentcdodds.com/images/small-circular-kent.png"
+                  alt="Kent C. Dodds"
+                  style="max-width: 80px; border-radius: 50%;"
+                />
+              </div>
+              <p>
+                <strong>Kent C. Dodds</strong> is a JavaScript software engineer and
+                teacher. He's taught hundreds of thousands of people how to make the world
+                a better place with quality software development tools and practices. He
+                lives with his wife and four kids in Utah.
+              </p>
+            </div>
+            <div>
+              <p>Learn more with Kent C. Dodds:</p>
+              <ul>
+                <li>
+                  <a href="https://kentcdodds.com/workshops">Live, professional workshops</a>:
+                  Join Kent C. Dodds from the comfort of your home for live remote workshops.
+                  Tickets are limited! 🎟
+                </li>
+                <li>
+                  <a href="https://testingjavascript.com">TestingJavaScript.com</a>: Jump on
+                  this self-paced workshop and learn the smart, efficient way to test any
+                  JavaScript application. 🏆
+                </li>
+              </ul>
+            </div>
+          </div>
+        `
+
+        const postText = `<div>${footer}</div><div style="margin-top=55px; font-style: italic;">(This article was posted to my blog at <a href="${blogUrl}">${blogUrl}</a>. You can <a href="${url}">read it online by clicking here</a>.)</div>`
+
+        // Hacky workaround for https://github.com/gaearon/overreacted.io/issues/65
+        const html = (edge.node.html || ``)
+          .replace(/href="\//g, `href="${siteUrl}/`)
+          .replace(/src="\//g, `src="${siteUrl}/`)
+          .replace(/"\/static\//g, `"${siteUrl}/static/`)
+          .replace(/,\s*\/static\//g, `,${siteUrl}/static/`)
+
+        return {
+          ...edge.node.frontmatter,
+          description: edge.node.excerpt,
+          date: edge.node.fields.date,
+          url,
+          guid: url,
+          custom_elements: [
+            {
+              'content:encoded': `<div style="width: 100%; margin: 0 auto; max-width: 800px; padding: 40px 40px;">
+                ${html}
+                ${postText}
+              </div>`,
+            },
+          ],
+        }
+      })
+    },
+    query: `
+     {
+       site {
+         siteMetadata {
+           title
+           description
+         }
+       }
+
+       allMdx(
+         limit: 1000,
+         filter: {
+           frontmatter: {published: {ne: false}}
+           fileAbsolutePath: {regex: "${filePathRegex}"}
+         }
+         sort: { order: DESC, fields: [frontmatter___date] }
+       ) {
+         edges {
+           node {
+             excerpt(pruneLength: 250)
+             html
+             fields {
+               slug
+               date
+             }
+             frontmatter {
+               title
+             }
+           }
+         }
+       }
+     }
+   `,
+    ...overrides,
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11064,6 +11064,18 @@
         "@emotion/babel-preset-css-prop": "^10.0.23"
       }
     },
+    "gatsby-plugin-feed": {
+      "version": "2.3.27",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-feed/-/gatsby-plugin-feed-2.3.27.tgz",
+      "integrity": "sha512-YdYyMi2k1d2vJtHq7GCFilWqHGBP74kMfv4vEjbGKnHwjUN+hu1u0ZbZHCO56OLz/Yyi+rG+pNdTDlbDFWD7lw==",
+      "requires": {
+        "@babel/runtime": "^7.7.6",
+        "@hapi/joi": "^15.1.1",
+        "fs-extra": "^8.1.0",
+        "lodash.merge": "^4.6.2",
+        "rss": "^1.2.2"
+      }
+    },
     "gatsby-plugin-manifest": {
       "version": "2.2.41",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-manifest/-/gatsby-plugin-manifest-2.2.41.tgz",
@@ -23804,6 +23816,30 @@
         "inherits": "^2.0.1"
       }
     },
+    "rss": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/rss/-/rss-1.2.2.tgz",
+      "integrity": "sha1-UKFpiHYTgTOnT5oF0r3I240nqSE=",
+      "requires": {
+        "mime-types": "2.1.13",
+        "xml": "1.0.1"
+      },
+      "dependencies": {
+        "mime-db": {
+          "version": "1.25.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz",
+          "integrity": "sha1-wY29fHOl2/b0SgJNwNFloeexw5I="
+        },
+        "mime-types": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
+          "integrity": "sha1-4HqqnGxrmnyjASxpADrSWjnpKog=",
+          "requires": {
+            "mime-db": "~1.25.0"
+          }
+        }
+      }
+    },
     "rsvp": {
       "version": "4.8.5",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
@@ -27882,6 +27918,11 @@
           "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
         }
       }
+    },
+    "xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU="
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "gatsby-link": "^2.2.28",
     "gatsby-plugin-catch-links": "^2.1.24",
     "gatsby-plugin-emotion": "^4.1.21",
+    "gatsby-plugin-feed": "^2.3.26",
     "gatsby-plugin-manifest": "^2.2.39",
     "gatsby-plugin-mdx": "^1.0.67",
     "gatsby-plugin-meta-redirect": "^1.1.1",


### PR DESCRIPTION
Hi Kent,

I've restored the RSS feed for your site, with a few changes that should reduce the time spent generating feeds in a build.

Previously, the entire content of every blog post was being grabbed to build the feed. This generated a >2MB file. I've taken steps to reduce this, with a few concessions.

* Only the most recent (25) posts are displayed instead of all posts. This is common for sites that produce a large amount of content, and doesn't pose an issue so long as RSS readers regularly poll for updates.
* Instead of displaying a post's content, only a banner image and prompt to view online are shown. This makes each item drastically smaller, and requires only the frontmatter for a page.

I hope this is sufficient to bring back the RSS feed, in spite of the troubles it may cause. Let me know if there's any further changes that would help!

Cheers, Nicholas :shipit: 

---

### Before

As an example, here's how [original feed](https://nchlswhttkr.keybase.pub/kentcdodds-rss/original-rss.xml) showed up in my reader. Some content isn't included, like the banner and subtitle.

<img width="1680" alt="Screen Shot 2020-02-20 at 12 47 17 pm" src="https://user-images.githubusercontent.com/26531118/74894159-4bf0ad80-53e2-11ea-9fe2-a4573a697876.png">

### After

With this PR, the [revised feed](https://nchlswhttkr.keybase.pub/kentcdodds-rss/revised-rss.xml) shows only the banner image and a prompt to view the post online. Changing the content is trivial though, if you want to add your footer back.

<img width="1680" alt="Screen Shot 2020-02-20 at 12 47 28 pm" src="https://user-images.githubusercontent.com/26531118/74894174-54e17f00-53e2-11ea-830e-f0ae6acca232.png">

**Some banner images were returning a 404 for me - they appear locally but not at kentcdodds.com, I'm not sure what the cause there is.**