### PR TITLE
remove duplicate slash in seo url

### DIFF
--- a/src/components/seo/index.js
+++ b/src/components/seo/index.js
@@ -1,4 +1,3 @@
-import path from 'path'
 import React from 'react'
 import Helmet from 'react-helmet'
 import {useStaticQuery, graphql} from 'gatsby'
@@ -19,7 +18,7 @@ function SEO({
     seo.description,
   image = `${seo.canonicalUrl}${metaImage || defaultMetaImage}`,
   url = postMeta.slug
-    ? `${seo.canonicalUrl}${path.sep}${postMeta.slug}`
+    ? `${seo.canonicalUrl}${postMeta.slug}`
     : seo.canonicalUrl,
   datePublished = isBlogPost ? postMeta.datePublished : false,
 }) {


### PR DESCRIPTION
I noticed when looking at the meta tags on your site that the `og:url` property had a double slash between the url and the slug.

`https://kentcdodds.com/blog/make-your-own-dev-tools` became `https://kentcdodds.com//blog/make-your-own-dev-tools` in the meta tags. Looking at it the SEO function was adding a `path.sep` in between the `canonicalUrl` and the `slug`. Removing it seems to fix the problem, at least I couldn't find any pages that still did it on my dev copy of the site.

Looks like the `onCreateMdxNode` function is creating nodes with the leading slash on the slug so there is no need to add the slash in the SEO tags.