### PR TITLE
Fix typo in Egghead link

### DIFF
--- a/content/blog/make-your-test-fail/index.mdx
+++ b/content/blog/make-your-test-fail/index.mdx
@@ -16,7 +16,7 @@ banner: './images/banner.jpg'
 bannerCredit: 'Photo by [chuttersnap](https://unsplash.com/photos/cGXdjyP6-NU)'
 ---
 
-**[Watch "Make Your Ready Fail" on egghead.io](https://egghead.io/lessons/jest-make-your-test-fail?pl=kent-s-blog-posts-as-screencasts-eefa540c)**
+**[Watch "Make Your Test Fail" on egghead.io](https://egghead.io/lessons/jest-make-your-test-fail?pl=kent-s-blog-posts-as-screencasts-eefa540c)**
 
 https://egghead.io/lessons/jest-make-your-test-fail?pl=kent-s-blog-posts-as-screencasts-eefa540c
 


### PR DESCRIPTION
fixed typo in Egghead link
- "Make Your Ready Fail" to "Make Your Test Fail"