### PR TITLE
Update Frontend Masters link to teacher page

### DIFF
--- a/src/pages/links.mdx
+++ b/src/pages/links.mdx
@@ -25,7 +25,7 @@ Links to some things about me...
 - [Workshops](https://kcd.im/workshops) - Workshops I've given
 - [egghead.io](https://kcd.im/egghead) - My [egghead.io](https://egghead.io)
   instructor page
-- [Frontend Masters Courses](https://frontendmasters.com/courses)
+- [Frontend Masters Courses](https://frontendmasters.com/teachers/kentcdodds/)
 - [Tech Chats](https://kcd.im/tech-chats) - A playlist of chats I've had with
   awesome people about tech stuff
   ([learn more](https://github.com/kentcdodds/ama/issues/125))


### PR DESCRIPTION
This PR fixes the link so that anyone who clicks on the *Frontend Masters Courses* link is taken to your teacher page instead of the general courses page on Frontend Masters.

If this was intentional, please feel free to close this PR!