### PR TITLE
Adding render copy on all browsers except in Safari

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3150,6 +3150,14 @@
         "fastq": "^1.6.0"
       }
     },
+    "@oieduardorabelo/use-user-agent": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@oieduardorabelo/use-user-agent/-/use-user-agent-1.0.6.tgz",
+      "integrity": "sha512-zWZn3WaygZrnvmgnd6NlivKGMljOlj+Aihd8ig5VESMP139Nv3KW95iLvOtjauwk5sSmWxRU6igyj5/u0aS36A==",
+      "requires": {
+        "ua-parser-js": "^0.7.21"
+      }
+    },
     "@pieh/friendly-errors-webpack-plugin": {
       "version": "1.7.0-chalk-2",
       "resolved": "https://registry.npmjs.org/@pieh/friendly-errors-webpack-plugin/-/friendly-errors-webpack-plugin-1.7.0-chalk-2.tgz",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@emotion/styled": "^10.0.27",
     "@mdx-js/mdx": "^1.5.8",
     "@mdx-js/react": "^1.5.8",
+    "@oieduardorabelo/use-user-agent": "^1.0.6",
     "@reach/router": "^1.3.3",
     "@sindresorhus/slugify": "^0.11.0",
     "ap-style-title-case": "^1.1.2",

--- a/src/components/search/index.js
+++ b/src/components/search/index.js
@@ -2,6 +2,7 @@ import React from 'react'
 import Img from 'gatsby-image'
 import styled from '@emotion/styled'
 import {Link as RouterLink} from '@reach/router'
+import {useUserAgent} from '@oieduardorabelo/use-user-agent'
 import {rankings as matchSorterRankings} from 'match-sorter'
 import MatchSorterWorker from './match-sorter.worker'
 import theme from '../../../config/theme'
@@ -44,6 +45,15 @@ function BlogPostCard({blogpost}) {
     )
   }
 
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const details = typeof window === `undefined` ? null : useUserAgent()
+  if (!details) {
+    return <span>No details</span>
+  }
+
+  const {browser} = details
+  const isSafari = browser.name === 'Safari'
+
   return (
     <div
       css={{
@@ -59,22 +69,24 @@ function BlogPostCard({blogpost}) {
     >
       <RouterLink to={slug} css={{color: 'initial'}}>
         <h2 css={{marginTop: 0}}>{title}</h2>
-        <div css={{width: '100%'}}>
-          <button
-            css={{
-              display: 'block',
-              width: '100%',
-              position: 'absolute',
-              bottom: '0',
-              left: '0',
-              borderTopRightRadius: '0',
-              borderTopLeftRadius: '0',
-            }}
-            onClick={copy}
-          >
-            {copyText}
-          </button>
-        </div>
+        {isSafari ? null : (
+          <div css={{width: '100%'}}>
+            <button
+              css={{
+                display: 'block',
+                width: '100%',
+                position: 'absolute',
+                bottom: '0',
+                left: '0',
+                borderTopRightRadius: '0',
+                borderTopLeftRadius: '0',
+              }}
+              onClick={copy}
+            >
+              {copyText}
+            </button>
+          </div>
+        )}
         <Img fluid={banner.childImageSharp.fluid} alt={keywords.join(', ')} />
         <div css={{margin: '16px 0 0 0'}}>{description}</div>
       </RouterLink>


### PR DESCRIPTION
**Issue:** `Navigator.clipboard` is not supported in Safari. 

Reference: https://developer.mozilla.org/en-US/docs/Web/API/Navigator/clipboard

**Solution:** Render  `copy URL` on all browsers except in Safari by detecting browsers user-agent.

<img width="1680" alt="Screen Shot 2020-04-12 at 12 26 39 PM" src="https://user-images.githubusercontent.com/57044804/79077813-df46b080-7cb8-11ea-8412-40853cfa250e.png">

