### PR TITLE
Add Container for upcoming event on post page

### DIFF
--- a/src/templates/post.js
+++ b/src/templates/post.js
@@ -179,14 +179,16 @@ function Post({data: {site, mdx}}) {
             justify-content: center;
           `}
         >
-          <UpcomingWorkshops
-            headline={
-              commonKeyword
-                ? titleCase(`Upcoming ${commonKeyword} Workshops`)
-                : 'Upcoming Workshops'
-            }
-            events={eventsByKeywords}
-          />
+          <Container noVerticalPadding>
+            <UpcomingWorkshops
+              headline={
+                commonKeyword
+                  ? titleCase(`Upcoming ${commonKeyword} Workshops`)
+                  : 'Upcoming Workshops'
+              }
+              events={eventsByKeywords}
+            />
+          </Container>
         </div>
       )}
       {keywords.map(keyword => keyword.toLowerCase()).includes('testing') && (


### PR DESCRIPTION
Added `<Container />` wrapper for an upcoming event on the post page. As you may see on the screenshot there weren't any paddings before.

![diff](https://user-images.githubusercontent.com/17102399/79632860-adc35e80-816a-11ea-8533-54e95aa296ac.jpg)