### PR TITLE
Remove hyphen from titles for SEO

### DIFF
--- a/content/podcast/01/01-ali-spittel/index.mdx
+++ b/content/podcast/01/01-ali-spittel/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Growing Your Skills And Career Through Teaching - with Ali Spittel
+title: Growing Your Skills And Career Through Teaching With Ali Spittel
 slug: growing-your-skills-and-career-through-teaching-with-ali-spittel
 simpleCastId: d1033b76-3035-4990-b7ae-0fc0c124bc50
 description:

--- a/content/podcast/01/02-cassidy-williams/index.mdx
+++ b/content/podcast/01/02-cassidy-williams/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Establishing Your Personal Brand - with Cassidy Williams
+title: Establishing Your Personal Brand With Cassidy Williams
 slug: establishing-your-personal-brand-with-cassidy-williams
 simpleCastId: 03bf57d4-e3d6-4922-88cb-5d23b713104a
 description:

--- a/content/podcast/01/03-dan-abramov/index.mdx
+++ b/content/podcast/01/03-dan-abramov/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Realigning Your Model of React After Hooks - With Dan Abramov
+title: Realigning Your Model of React After Hooks With Dan Abramov
 slug: realigning-your-model-of-react-after-hooks-with-dan-abramov
 simpleCastId: 62f56a13-d28a-4168-ade5-e70297d9c02c
 description:

--- a/content/podcast/01/04-dan-abramov/index.mdx
+++ b/content/podcast/01/04-dan-abramov/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: A Rundown Of What's Next For React - With Dan Abramov
+title: A Rundown Of What's Next For React With Dan Abramov
 slug: a-rundown-of-whats-next-for-react-with-dan-abramov
 simpleCastId: 62a1da0d-f39d-4d65-97d7-8faa48ae046f
 description: 'Dan Abramov talks about the future of React.'

--- a/content/podcast/01/05-david-khourshid/index.mdx
+++ b/content/podcast/01/05-david-khourshid/index.mdx
@@ -1,6 +1,5 @@
 ---
-title:
-  Make Your Apps Resilient Using Finite State Machines - With David Khourshid
+title: Make Your Apps Resilient Using Finite State Machines With David Khourshid
 slug: make-your-apps-resilient-finite-state-machines-with-david-khourshid
 simpleCastId: ae3dca30-7df6-4402-894a-912d080b0ced
 description:

--- a/content/podcast/01/06-emma-wedekind/index.mdx
+++ b/content/podcast/01/06-emma-wedekind/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Creating Successful Mentor Relationships - With Emma Wedekind
+title: Creating Successful Mentor Relationships With Emma Wedekind
 slug: creating-successful-mentor-relationships-with-emma-wedekind
 simpleCastId: e90a120e-f552-49d3-ac39-8b9e1bd79d8f
 description:

--- a/content/podcast/01/07-eric-berry/index.mdx
+++ b/content/podcast/01/07-eric-berry/index.mdx
@@ -1,6 +1,5 @@
 ---
-title:
-  Funding Open-Source Maintainers Using Ethical Advertising - With Eric Berry
+title: Funding Open-Source Maintainers Using Ethical Advertising With Eric Berry
 slug: funding-open-source-maintainers-using-ethical-advertising-with-eric-berry
 simpleCastId: a7d3aafb-6be2-4edf-85e1-d6281ad63b57
 description:

--- a/content/podcast/01/08-lin-and-till/index.mdx
+++ b/content/podcast/01/08-lin-and-till/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: The State Of WebAssembly - With Lin Clark and Till Schneidereit
+title: The State Of WebAssembly With Lin Clark and Till Schneidereit
 slug: the-state-of-webassembly-with-lin-clark-and-till-schneidereit
 simpleCastId: f59a8446-5253-4e72-9993-89a485b70c1d
 description:

--- a/content/podcast/01/09-peggy-rayzis/index.mdx
+++ b/content/podcast/01/09-peggy-rayzis/index.mdx
@@ -1,6 +1,6 @@
 ---
 title:
-  A Few Excellent Reasons For Why You Should Give GraphQL A Try - With Peggy
+  A Few Excellent Reasons For Why You Should Give GraphQL A Try With Peggy
   Rayzis
 slug: a-few-excellent-reasons-for-why-you-should-give-graphql-a-try-with-peggy-rayzis
 simpleCastId: 63fc78d1-6fd7-495a-96ce-3d58c0009633

--- a/content/podcast/01/10-sara-vieira/index.mdx
+++ b/content/podcast/01/10-sara-vieira/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: There Aren't Any Shortcuts To Expertise - With Sara Vieira
+title: There Aren't Any Shortcuts To Expertise With Sara Vieira
 slug: there-arent-any-shortcuts-to-expertise-with-sara-vieira
 simpleCastId: fd13f437-7227-4f9d-a2af-7890cda19a26
 description: 'Sara Vieira talks about the road to expertise.'

--- a/content/podcast/01/11-scott-hanselman/index.mdx
+++ b/content/podcast/01/11-scott-hanselman/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Become Intentional With Your Time - With Scott Hanselman
+title: Become Intentional With Your Time With Scott Hanselman
 slug: become-intentional-with-your-time-with-scott-hanselman
 simpleCastId: 61f0d056-cffd-4084-80ce-1574fee4e86e
 description: 'Scott Hanselman talks about how to be intentional with your life.'

--- a/content/podcast/01/12-shawn-wang/index.mdx
+++ b/content/podcast/01/12-shawn-wang/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: You Can Learn A Lot For The Low Price Of Your Ego - With Shawn Wang
+title: You Can Learn A Lot For The Low Price Of Your Ego With Shawn Wang
 slug: you-can-learn-a-lot-for-the-low-price-of-your-ego-with-shawn-wang
 simpleCastId: 374c602b-5c23-4e64-9b27-0f54d7fcc483
 description:

--- a/content/podcast/01/13-suz-hinton/index.mdx
+++ b/content/podcast/01/13-suz-hinton/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Getting Started With Code Live-Streaming - With Suz Hinton
+title: Getting Started With Code Live-Streaming With Suz Hinton
 slug: getting-started-with-code-live-streaming-with-suz-hinton
 simpleCastId: b1cfca39-6b35-48b9-8457-211fa89130cf
 description:

--- a/content/podcast/01/14-shirley-wu/index.mdx
+++ b/content/podcast/01/14-shirley-wu/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Lessons Learned From Four Major Projects - with Shirley Wu
+title: Lessons Learned From Four Major Projects With Shirley Wu
 slug: lessons-learned-from-four-major-projects-with-shirley-wu
 simpleCastId: e8df0f56-1daf-45d6-ad98-f81c81fc25cb
 description:


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/518406/79917401-4b26c880-83df-11ea-9125-07f1a89eaebf.png)

The hyphen in the titles was causing them to break in the Google search results. I updated the titles in Simplecast as well.