### PR TITLE
(fix): the formatting of date key in front matter for blogs

### DIFF
--- a/content/blog/compound-components-with-react-hooks/index.mdx
+++ b/content/blog/compound-components-with-react-hooks/index.mdx
@@ -1,6 +1,6 @@
 ---
 slug: compound-components-with-react-hooks
-date: 2019-02-18
+date: '2019-02-18'
 title: 'React Hooks: Compound Components'
 author: 'Kent C. Dodds'
 description: How do compound components change with React hooks?

--- a/content/blog/control-props-vs-state-reducers/index.mdx
+++ b/content/blog/control-props-vs-state-reducers/index.mdx
@@ -1,6 +1,6 @@
 ---
 slug: control-props-vs-state-reducers
-date: 2018-06-11
+date: '2018-06-11'
 title: 'When to use Control Props or State Reducers'
 author: 'Kent C. Dodds'
 description:

--- a/content/blog/full-time-educator/index.mdx
+++ b/content/blog/full-time-educator/index.mdx
@@ -1,6 +1,6 @@
 ---
 slug: full-time-educator
-date: 2019-02-17
+date: '2019-02-17'
 title: "🚨 Big Announcement: I'm a full-time educator! 👨‍🏫"
 author: 'Kent C. Dodds'
 description:

--- a/content/blog/intentional-career-building/index.mdx
+++ b/content/blog/intentional-career-building/index.mdx
@@ -1,6 +1,6 @@
 ---
 slug: intentional-career-building
-date: 2019-02-11
+date: '2019-02-11'
 title: 'Intentional Career Building'
 author: 'Kent C. Dodds'
 description:

--- a/content/blog/should-i-usestate-or-usereducer/index.mdx
+++ b/content/blog/should-i-usestate-or-usereducer/index.mdx
@@ -1,6 +1,6 @@
 ---
 slug: should-i-usestate-or-usereducer
-date: 2020-03-09
+date: '2020-03-09'
 title: 'Should I useState or useReducer?'
 author: 'Kent C. Dodds'
 description:

--- a/content/blog/unit-vs-integration-vs-e2e-tests/index.mdx
+++ b/content/blog/unit-vs-integration-vs-e2e-tests/index.mdx
@@ -1,6 +1,6 @@
 ---
 slug: unit-vs-integration-vs-e2e-tests
-date: 2020-04-15
+date: '2020-04-15'
 title: 'Static vs Unit vs Integration vs E2E Testing for Frontend Apps'
 author: 'Kent C. Dodds'
 description: _What these mean, why they matter, and why they don't_
@@ -88,7 +88,9 @@ describe('todo app', () => {
 
     cy.findByText(/login/i).click()
 
-    cy.findByLabelText(/add todo/i).type(todo.description).type('{enter}')
+    cy.findByLabelText(/add todo/i)
+      .type(todo.description)
+      .type('{enter}')
 
     cy.findByTestId('todo-0').should('have.value', todo.description)
 
@@ -251,10 +253,10 @@ PR will get rejected unless it includes tests? Is it because testing enhances
 your workflow?
 
 The biggest and most important reason that I write tests is **CONFIDENCE**. I
-want to be confident that the code I'm writing for the future won't break the app
-that I have running in production today. So whatever I do, I want to make sure
-that the kinds of tests I write bring me the most confidence possible and I need
-to be cognizant of the trade-offs I'm making when testing.
+want to be confident that the code I'm writing for the future won't break the
+app that I have running in production today. So whatever I do, I want to make
+sure that the kinds of tests I write bring me the most confidence possible and I
+need to be cognizant of the trade-offs I'm making when testing.
 
 ## Let's talk trade-offs
 


### PR DESCRIPTION
## PR

### DESCRIPTION
The formatting of date was not showing up properly for some of the blogs because it was not having quotes in the front matter.

For example **2019-02-11** value was provided to date key in front matter instead of **'2019-02-11'**, which was causing the improper formatting of date.

### SCREENSHOT(S)
#### Old formatting

https://kentcdodds.com/blog/unit-vs-integration-vs-e2e-tests
<img width="802" alt="unit-vs-integration-vs-e2e-tests-old" src="https://user-images.githubusercontent.com/19193724/80918394-4f10fe00-8d82-11ea-85b1-80d234ef00bb.png">

https://kentcdodds.com/blog/control-props-vs-state-reducers
<img width="743" alt="control-props-vs-state-reducers-old" src="https://user-images.githubusercontent.com/19193724/80918393-4f10fe00-8d82-11ea-9323-f7835f6f7021.png">

https://kentcdodds.com/blog/should-i-usestate-or-usereducer
<img width="756" alt="should-i-usestate-or-usereducer-old" src="https://user-images.githubusercontent.com/19193724/80918395-4fa99480-8d82-11ea-814a-a35e5822f300.png">

https://kentcdodds.com/blog/compound-components-with-react-hooks
<img width="738" alt="compound-components-with-react-hooks-old" src="https://user-images.githubusercontent.com/19193724/80918390-4d473a80-8d82-11ea-9920-afbb6067a361.png">

https://kentcdodds.com/blog/full-time-educator
<img width="746" alt="full-time-educator-old" src="https://user-images.githubusercontent.com/19193724/80918397-51735800-8d82-11ea-8e35-dc321ea09f2b.png">

https://kentcdodds.com/blog/intentional-career-building
<img width="735" alt="intentional-career-building-old" src="https://user-images.githubusercontent.com/19193724/80918396-50422b00-8d82-11ea-8aac-8f43f4c434cb.png">


#### Fixed formatting

http://localhost:8000/blog/unit-vs-integration-vs-e2e-tests
<img width="800" alt="unit-vs-integration-vs-e2e-tests-new" src="https://user-images.githubusercontent.com/19193724/80918409-605a0a80-8d82-11ea-80a2-3d4bd0d886a5.png">

http://localhost:8000/blog/control-props-vs-state-reducers
<img width="747" alt="control-props-vs-state-reducers-new" src="https://user-images.githubusercontent.com/19193724/80918414-62bc6480-8d82-11ea-8f51-2f2dd85df1a8.png">

http://localhost:8000/blog/should-i-usestate-or-usereducer
<img width="753" alt="should-i-usestate-or-usereducer-new" src="https://user-images.githubusercontent.com/19193724/80918411-6223ce00-8d82-11ea-910c-7ea2408db530.png">

http://localhost:8000/blog/compound-components-with-react-hooks
<img width="749" alt="compound-components-with-react-hooks-new" src="https://user-images.githubusercontent.com/19193724/80918416-6354fb00-8d82-11ea-88b8-fd1971fd23ad.png">

http://localhost:8000/blog/full-time-educator
<img width="746" alt="full-time-educator-new" src="https://user-images.githubusercontent.com/19193724/80918412-62bc6480-8d82-11ea-9383-2941aa478473.png">

http://localhost:8000/blog/intentional-career-building
<img width="740" alt="intentional-career-building-new" src="https://user-images.githubusercontent.com/19193724/80918417-63ed9180-8d82-11ea-9895-3f25697cb720.png">


### HOW TO TEST
http://localhost:8000/blog/unit-vs-integration-vs-e2e-tests
http://localhost:8000/blog/control-props-vs-state-reducers
http://localhost:8000/blog/should-i-usestate-or-usereducer
http://localhost:8000/blog/compound-components-with-react-hooks
http://localhost:8000/blog/full-time-educator
http://localhost:8000/blog/intentional-career-building
