### PR TITLE
(fix): the focus and hover effects issue in TechToggle buttons

### DIFF
--- a/src/pages/workshops/index.js
+++ b/src/pages/workshops/index.js
@@ -110,15 +110,21 @@ function RemoteWorkshops({data: {workshops}}) {
                 css={css`
                   ${techToggleIsActive(displayedTech, tech)
                     ? `
-                  color: white; background: #2F313E;
-                  :hover {
+                  color: white; 
+                  background: #2F313E;
+                  :hover,
+                  :focus {
                     color: white !important;
-                    background: #232323 !important;}`
+                    background: #232323 !important;
+                  }`
                     : `
-                  color: black; background: white;
-                  :hover {
+                  color: black; 
+                  background: white;
+                  :hover,
+                  :focus {
                     color: black !important;
-                    background: #fafafa; !important}`}
+                    background: #fafafa !important;
+                  }`}
                 `}
                 key={tech}
                 onClick={() => {


### PR DESCRIPTION
## PR

### DESCRIPTION
1. Click on the <TechToggle/> button(JavaScript, React, Testing) on the https://kentcdodds.com/workshops/ page.
2. After clicking the button hover out of the button(don't click anywhere).
3. You will see that it is still not in active state.
4. Clicking outside of button makes it in active state.
5. Also https://github.com/kentcdodds/kentcdodds.com/compare/master...abhishekjakhar:FIX-TechToggle?expand=1#diff-98f988c8a7cca583f0c1e11e5ab203bbL121 the **!important** has been written after **semicolon**, this has also been fixed.

### SCREENSHOT

#### <TechToggle/> Component

<img width="1279" alt="TechToggle" src="https://user-images.githubusercontent.com/19193724/80988304-f197b280-8e50-11ea-86af-df6a8d754492.png">


### HOW TO TEST
1. Got to http://localhost:8000/workshops/ page.
2. Click on the <TechToggle/> buttons(JavaScript, React, Testing) 
3. After clicking hover outside of the button, it should retain the active state.


