### PR TITLE
correct getByRole usage in code snippet

### DIFF
--- a/content/blog/common-mistakes-with-react-testing-library/index.mdx
+++ b/content/blog/common-mistakes-with-react-testing-library/index.mdx
@@ -283,7 +283,7 @@ screen.getByText(/hello world/i)
 // because the text is broken up by multiple elements. In this case, you can
 // provide a function for your text matcher to make your matcher more flexible.
 
-screen.getByRole('button', {/hello world/i})
+screen.getByRole('button', {name: /hello world/i})
 // ✅ works!
 ```
 


### PR DESCRIPTION
forgot `name:`