### PR TITLE
(fix): the z-index of fade-out effect on podcast page

### DIFF
--- a/src/components/podcast/list.js
+++ b/src/components/podcast/list.js
@@ -20,7 +20,7 @@ export default function PodcastList({data}) {
     >
       {data.nodes.map(episode => (
         <li
-          key={episode.frontmatter.id}
+          key={episode.frontmatter.simpleCastId}
           css={css({
             marginBottom: 10,
           })}

--- a/src/templates/podcast-episode.js
+++ b/src/templates/podcast-episode.js
@@ -24,7 +24,7 @@ const Sidebar = styled.aside(
       visibility: 'hidden',
       position: 'absolute',
       bottom: '0',
-      zIndex: '10',
+      zIndex: '9',
       width: '100%',
       height: 40,
       backgroundImage:


### PR DESCRIPTION
## PR

### DESCRIPTION

- The fade-out effect div on podcast page is coming above the mobile navigation and causing design issue. Reducing the value of fade-out div z-index from 10 to 9 has fixed the issue.
- Fixed the key warning in PodcastList component by passing **episode.frontmatter.simpleCastId** instead of **episode.frontmatter.id** to the key prop.


### SCREENSHOT(S) _iPhone(X)_
#### Podcast page with fade-out effect div
![podcast-page](https://user-images.githubusercontent.com/19193724/81578335-48a90480-93c8-11ea-9927-2ceee2f07046.png)

#### The bug on mobile navigation because of face-out div
![poadcast-page-bug](https://user-images.githubusercontent.com/19193724/81578343-4ba3f500-93c8-11ea-8b8d-b190d5926c03.png)

#### The fix
![poadcast-page-fix](https://user-images.githubusercontent.com/19193724/81578356-4fd01280-93c8-11ea-8e97-1ef17abf45b0.png)


### HOW TO TEST

- Go to podcast page on mobile
- Select any podcast and proceed to /chat-with-kent-podcast route(https://kentcdodds.com/chats-with-kent-podcast/seasons/02/episodes/lindsey-kopacz-chats-with-kent-about-a11y).
- Open up the mobile navigation from hamburger menu
- The fade-out div should not come above the mobile navigation
- Check the console, the key prop warning should also have been fixed