### PR TITLE
fix: the responsive display of blog and writing blog page

### DIFF
--- a/src/pages/blog.mdx
+++ b/src/pages/blog.mdx
@@ -1,6 +1,8 @@
 ---
 title: Blog | Kent C. Dodds
 description: Search Kent C. Dodds blog posts
+maxWidth: '90vw'
+noMobileHorizontalPadding: true
 ---
 
 import BlogScreen from '../screens/blog'

--- a/src/pages/blog.mdx
+++ b/src/pages/blog.mdx
@@ -1,7 +1,6 @@
 ---
 title: Blog | Kent C. Dodds
 description: Search Kent C. Dodds blog posts
-maxWidth: '90vw'
 ---
 
 import BlogScreen from '../screens/blog'

--- a/src/pages/writing/blog.mdx
+++ b/src/pages/writing/blog.mdx
@@ -1,6 +1,8 @@
 ---
 title: Writing Blog | Kent C. Dodds
 description: Search Kent C. Dodds writing blog posts
+maxWidth: '90vw'
+noMobileHorizontalPadding: true
 ---
 
 import BlogScreen from '../../screens/writing-blog'

--- a/src/pages/writing/blog.mdx
+++ b/src/pages/writing/blog.mdx
@@ -1,7 +1,6 @@
 ---
 title: Writing Blog | Kent C. Dodds
 description: Search Kent C. Dodds writing blog posts
-maxWidth: '90vw'
 ---
 
 import BlogScreen from '../../screens/writing-blog'

--- a/src/templates/markdown-page.js
+++ b/src/templates/markdown-page.js
@@ -5,6 +5,9 @@ import Layout from 'components/layout'
 import BigHero from 'components/big-hero'
 import theme from '../../config/theme'
 
+import {css} from '@emotion/core'
+import {bpMaxSM} from 'lib/breakpoints'
+
 function MarkdownPage({children, pageContext: {frontmatter}}) {
   return (
     <>
@@ -20,7 +23,17 @@ function MarkdownPage({children, pageContext: {frontmatter}}) {
         frontmatter={frontmatter}
         headerColor={theme.colors.white}
       >
-        <Container maxWidth={frontmatter.maxWidth}>{children}</Container>
+        <Container
+          maxWidth={frontmatter.maxWidth}
+          css={css`
+            ${bpMaxSM} {
+              padding: 20px
+                ${frontmatter.noMobileHorizontalPadding ? 0 : '20'}px;
+            }
+          `}
+        >
+          {children}
+        </Container>
       </Layout>
     </>
   )


### PR DESCRIPTION
## PR

### DESCRIPTION

The Blog page and Writing blog page are having extra 20px padding on left and right side each, which is making the display very narrow on mobile phones. This is happening because the Blog and Writing blog page have been given maximum width of 90vw, which limits it from expanding to the full width.

The blog and writing blog page are being passed down to the markdown-page.js template which is wrapping all of it's children with `<Container/> `and the default maximum width value of `<Container/>` is 800px which is being used other pages also for example about, links, info etc.

The 800px is same as 90vw, so removing the 90vw will not affect in any way, instead it will make the layout consistent(blog and writing blog page will have the same maximum width as about, links, info, appearances etc pages)

### SCREENSHOT(S) _iPhone(X)_
#### Expected Behaviour

<img width="400" alt="blog-fixed" src="https://user-images.githubusercontent.com/19193724/82061455-5de2a380-96e6-11ea-9bc0-40dcd77405f2.png">

<img width="400" alt="writing-blog-fixed" src="https://user-images.githubusercontent.com/19193724/82061496-6a66fc00-96e6-11ea-98c5-e272bd9d6777.png">

#### Actual Behaviour

<img width="400" alt="blog-bug" src="https://user-images.githubusercontent.com/19193724/82061546-7bb00880-96e6-11ea-8ebf-0fea6d1da730.png">

<img width="400" alt="writing-blog-bug" src="https://user-images.githubusercontent.com/19193724/82061584-8a96bb00-96e6-11ea-9a29-5847ac3307c6.png">

### HOW TO TEST

- Go to blogs page(http://localhost:8000/blog/) and Writing Blog page(http://localhost:8000/writing/blog/)
- The page should not be having extra 20px padding on left and right side, which means it should align with starting of header logo and end of hamburger menu.

