### PR TITLE
Change useContext to useCount

### DIFF
--- a/content/blog/application-state-management-with-react/index.mdx
+++ b/content/blog/application-state-management-with-react/index.mdx
@@ -288,7 +288,7 @@ function CountPage() {
 > context too soon!
 
 And what's cool about this approach is that we could put all the logic for
-common ways to update the state in our `useContext` hook:
+common ways to update the state in our `useCount` hook:
 
 ```jsx
 function useCount() {


### PR DESCRIPTION
I think it should be `useCount` in this sentence
`And what's cool about this approach is that we could put all the logic for
common ways to update the state in our `useCount` hook`