### PR TITLE
fix spelling mistake existance -> existence

### DIFF
--- a/content/blog/common-mistakes-with-react-testing-library/index.mdx
+++ b/content/blog/common-mistakes-with-react-testing-library/index.mdx
@@ -394,7 +394,7 @@ use it's utilities over `fireEvent`.
 
 **Advice: Use `@testing-library/user-event` over `fireEvent` where possible.**
 
-## Using `query*` variants for _anything_ except checking for non-existance
+## Using `query*` variants for _anything_ except checking for non-existence
 
 > Importance: high
 


### PR DESCRIPTION
Fixes a common spelling mistake in the «Common mistakes with react testing library» blog post.