### PR TITLE
Typo on import

### DIFF
--- a/content/blog/fix-the-not-wrapped-in-act-warning/index.mdx
+++ b/content/blog/fix-the-not-wrapped-in-act-warning/index.mdx
@@ -527,7 +527,7 @@ test('increment and decrement updates the count', () => {
 })
 ```
 
-You'll notice that we're pulling `act` from `@teating-library/react-hooks` and
+You'll notice that we're pulling `act` from `@testing-library/react-hooks` and
 that's because it simply re-exports the `act` function from
 `react-test-renderer` so you don't need to add an additional export. Nice
 right!?


### PR DESCRIPTION
Update import from `teating` to `testing`.