### PR TITLE
Fix error on the second example

### DIFF
--- a/content/blog/stop-mocking-fetch/index.mdx
+++ b/content/blog/stop-mocking-fetch/index.mdx
@@ -79,10 +79,10 @@ test('clicking "confirm" submits payment', async () => {
   const shoppingCart = buildShoppingCart()
   render(<Checkout shoppingCart={shoppingCart} />)
 
-  window.fetch.mockResolvedValueOnce(() => ({
+  window.fetch.mockResolvedValueOnce({
     ok: true,
     json: async () => ({success: true}),
-  }))
+  })
 
   userEvent.click(screen.getByRole('button', {name: /confirm/i}))
 


### PR DESCRIPTION
There was an error on the second example of this post. `mockResolvedValueOnce` accepts as a parameter the mocked result value, but there was a function in the example and it didn't work. I guess it was mistaken with `mockImplementationOnce`.