### PR TITLE
docs(office-hourse): Link directly to local time

### DIFF
--- a/src/pages/office-hours/index.mdx
+++ b/src/pages/office-hours/index.mdx
@@ -12,8 +12,8 @@ invited.
 To join, simply join the [KCD Discord](/discord) community, and jump in the "💻
 Kent live" video channel and the "💬-kent-live" text channel.
 
-Hours are weekly on Monday at 9:30-10:30 AM
-[Mountain Time](https://www.thetimezoneconverter.com/) and Thursday 4:00-5:00 PM
-[Mountain Time](https://www.thetimezoneconverter.com/).
+Hours are weekly on Monday at [9:30-10:30 AM
+Mountain Time](https://www.thetimezoneconverter.com/?t=9%3A30%20am&tz=Mountain%20Time%20(MT)&) and Thursday [4:00-5:00 PM
+Mountain Time](https://www.thetimezoneconverter.com/?t=4%3A00%20pm&tz=Mountain%20Time%20(MT)&).
 
 Get that in your calendar so you don't miss out!


### PR DESCRIPTION
Built with https://www.thetimezoneconverter.com/event_link.html.

Right now it's slightly confusing that a "Mountain Time" link links to PDT. It seems to remember the old input but on my initial (I guess) visit it used PDT. It was somewhat suspicious to me that San Francisco would be considered Mountain Time but you Americans are weird anyway when it comes to measuring things so it wasn't that obvious to me:wink: 