### PR TITLE
Fix useErrorHandler hook name in example

### DIFF
--- a/content/blog/use-react-error-boundary-to-handle-errors-in-react/index.mdx
+++ b/content/blog/use-react-error-boundary-to-handle-errors-in-react/index.mdx
@@ -403,7 +403,7 @@ Alternatively, let's say you're using a hook that gives you the error:
 function Greeting() {
   const [name, setName] = React.useState('')
   const {status, greeting, error} = useGreeting(name)
-  useHandleError(error)
+  useErrorHandler(error)
 
   function handleSubmit(event) {
     event.preventDefault()


### PR DESCRIPTION
The name of the hook should be `useErrorHandler` instead of `useHandleError `.