### PR TITLE
Add missing word

### DIFF
--- a/content/blog/unit-vs-integration-vs-e2e-tests/index.mdx
+++ b/content/blog/unit-vs-integration-vs-e2e-tests/index.mdx
@@ -329,7 +329,7 @@ Earlier I told you to remember two things:
 >   mock those dependencies (effectively swapping what could be thousands of
 >   lines of code with only a few).
 
-What those are saying is that the lower the trophy you are, the less code your
+What those are saying is that the lower down the trophy you are, the less code your
 tests are testing. If you're operating at a low level you need more tests to
 cover the same number of lines of code in your application as a single test
 could higher up the trophy. In fact, as you go lower down the testing trophy,


### PR DESCRIPTION
I think it was supposed to be "the lower **down** the trophy" instead of just "the lower the trophy".