### PR TITLE
Updates the path of mocked utils.js

### DIFF
--- a/content/blog/but-really-what-is-a-javascript-mock/index.mdx
+++ b/content/blog/but-really-what-is-a-javascript-mock/index.mdx
@@ -347,7 +347,7 @@ And with that, we can update our test:
 ```js
 // __tests__/thumb-war.js
 import thumbWar from '../thumb-war'
-import * as utilsMock from '../utils'
+import * as utilsMock from '../__mocks__/utils'
 
 jest.mock('../utils')
 


### PR DESCRIPTION
This might be a typo issue. This change updates the reference of mock utils.js. I have verified the changes in this repo
https://github.com/pragyaPS/react-playground/blob/eject-dependencies/src/__tests__/utils.spec.js