### PR TITLE
fix(content) typo in uses: boots -> boosts

### DIFF
--- a/src/pages/uses/index.mdx
+++ b/src/pages/uses/index.mdx
@@ -196,7 +196,7 @@ https://www.youtube.com/watch?v=N3wY9kNnmQA
   professional studios all the time.
 - [Heil Sound Microphone Boom](https://amazon.com/dp/B004PJ414I/) - This is
   attached to my desk and reaches over my left monitor to get to my face.
-- [Cloudlifter](https://amazon.com/dp/B004MQSV04/) - Boots the power of my
+- [Cloudlifter](https://amazon.com/dp/B004MQSV04/) - Boosts the power of my
   passive microphone. It's silly easy to use.
 - [Pyle 2-Channel Audio Mixer](https://amazon.com/dp/B003CY6OHY/) - This is the
   last place my microphone audio goes before it heads into my computer.


### PR DESCRIPTION
Hi! I was just looking at your /uses page and noticed the minor typo. Thanks.