### PR TITLE
Remove duplicate `actionTypes`

### DIFF
--- a/content/blog/the-state-reducer-pattern-with-react-hooks/index.mdx
+++ b/content/blog/the-state-reducer-pattern-with-react-hooks/index.mdx
@@ -465,7 +465,7 @@ function useToggle({reducer = toggleReducer} = {}) {
   return {on, toggle, setOn, setOff}
 }
 
-// export {useToggle, actionTypes, toggleReducer, actionTypes}
+// export {useToggle, actionTypes, toggleReducer}
 
 function Toggle() {
   const [clicksSinceReset, setClicksSinceReset] = React.useState(0)


### PR DESCRIPTION
Remove duplicate `actionTypes` in *Conclusion* code example.
It's a minor mistake in an otherwise perfect article.

Thanks for creating such a great article.