### PR TITLE
enable "Add a Keyword for this Search..." context menu item in Firefo…

### DIFF
--- a/src/components/search/index.js
+++ b/src/components/search/index.js
@@ -225,19 +225,28 @@ function Search(props) {
     })
   }
 
+  function handlePreventSubmit(event) {
+    // the form is used only to enable https://support.mozilla.org/en-US/kb/how-search-from-address-bar
+    // we want to prevent an actual submit (page reload) when pressing Enter
+    event.preventDefault()
+  }
+
   return (
     <div>
       <div css={{maxWidth: 500, margin: 'auto'}}>
         <div css={{position: 'relative'}}>
-          <input
-            css={{width: '100%', paddingRight: 50}}
-            onChange={event => setSearch(event.target.value)}
-            type="search"
-            placeholder="Search Blogposts"
-            aria-label="Search Blogposts"
-            value={search}
-            autoFocus
-          />
+          <form action="/blog" method="GET" onSubmit={handlePreventSubmit}>
+            <input
+              name="q" /* the GET query parameter in https://kentcdodds.com/blog/?q=test */
+              css={{width: '100%', paddingRight: 50}}
+              onChange={event => setSearch(event.target.value)}
+              type="search"
+              placeholder="Search Blogposts"
+              aria-label="Search Blogposts"
+              value={search}
+              autoFocus
+            />
+          </form>
           <div
             css={{
               position: 'absolute',


### PR DESCRIPTION
saving the bookmark and using the keyword search worked fine for me from Firefox address bar from localhost after `npm run dev`
...and the search works the same as before in Chrome and Safari on Mac...
(manual test only, no idea how to automate browser bookmarking)

![keyword search](https://user-images.githubusercontent.com/1087670/93922955-f9c69080-fd12-11ea-925c-9fb2c6a1f882.png)