### PR TITLE
remove cleanup example (issue #561) and use screen in 'Avoid Nesting when you're Testing'

### DIFF
--- a/content/blog/avoid-nesting-when-youre-testing/index.mdx
+++ b/content/blog/avoid-nesting-when-youre-testing/index.mdx
@@ -349,8 +349,10 @@ function setup() {
   const handleSubmit = jest.fn()
   const utils = render(<Login onSubmit={handleSubmit} />)
   const user = {username: 'michelle', password: 'smith'}
-  const changeUsernameInput = value => userEvent.type(utils.getByLabelText(/username/i), value)
-  const changePasswordInput = value => userEvent.type(utils.getByLabelText(/password/i), value)
+  const changeUsernameInput = value =>
+    userEvent.type(utils.getByLabelText(/username/i), value)
+  const changePasswordInput = value =>
+    userEvent.type(utils.getByLabelText(/password/i), value)
   const clickSubmit = () => userEvent.click(utils.getByText(/submit/i))
   return {
     ...utils,
@@ -443,122 +445,6 @@ after it. If you try to put that code inline within your test, then a test
 failure would result in your cleanup not running which could then lead to other
 tests failing, ultimately resulting in a lot of error output that is harder to
 debug.
-
-> NOTE: This example was written before `@testing-library/react@9` which made
-> cleanup automatic. But the concept still applies and I didn't want to rewrite
-> the example 😅
-
-For example, React Testing Library will insert your component into the document,
-and if you don't cleanup after each test, then your tests can run over
-themselves:
-
-```jsx
-import {render} from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
-import React from 'react'
-
-import Login from '../login'
-
-test('example 1', () => {
-  const handleSubmit = jest.fn()
-  const {getByLabelText} = render(<Login onSubmit={handleSubmit} />)
-  userEvent.type(getByLabelText(/username/i), 'kentcdodds')
-  userEvent.type(getByLabelText(/password/i), 'ilovetwix')
-  // more test here
-})
-
-test('example 2', () => {
-  const handleSubmit = jest.fn()
-  const {getByLabelText} = render(<Login onSubmit={handleSubmit} />)
-  // 💣 this will blow up because the `getByLabelText` is actually querying the
-  // entire document, and because we didn't cleanup after the previous test
-  // we'll get an error indicating that RTL found more than one field with the
-  // label "username"
-  userEvent.type(getByLabelText(/username/i), 'kentcdodds')
-  // more test here
-})
-```
-
-Fixing this is pretty simple, you need to execute the `cleanup` method from
-`@testing-library/react` after each test.
-
-```jsx {1,13,21}
-import {cleanup, render} from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
-import React from 'react'
-
-import Login from '../login'
-
-test('example 1', () => {
-  const handleSubmit = jest.fn()
-  const {getByLabelText} = render(<Login onSubmit={handleSubmit} />)
-  userEvent.type(getByLabelText(/username/i), 'kentcdodds')
-  userEvent.type(getByLabelText(/password/i), 'ilovetwix')
-  // more test here
-  cleanup()
-})
-
-test('example 2', () => {
-  const handleSubmit = jest.fn()
-  const {getByLabelText} = render(<Login onSubmit={handleSubmit} />)
-  userEvent.type(getByLabelText(/username/i), 'kentcdodds')
-  // more test here
-  cleanup()
-})
-```
-
-However, if you _don't_ use `afterEach` to do this then if a test fails your
-cleanup wont run, like this:
-
-```jsx {5-7}
-test('example 1', () => {
-  const handleSubmit = jest.fn()
-  const {getByLabelText} = render(<Login onSubmit={handleSubmit} />)
-  userEvent.type(getByLabelText(/username/i), 'kentcdodds')
-  // 💣 the following typo will result in a error thrown:
-  //   "no field with the label matching passssword"
-  userEvent.type(getByLabelText(/passssword/i), 'ilovetwix')
-  // more test here
-  cleanup()
-})
-```
-
-Because of this, the `cleanup` function in "example 1" will not run and then
-"example 2" wont run properly, so instead of only seeing 1 test failure, you'll
-see that all the tests failed and it'll make it much harder to debug.
-
-So instead, you should use `afterEach` and that will ensure that even if your
-test fails, you can cleanup:
-
-```jsx
-import {cleanup, render} from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
-import React from 'react'
-
-import Login from '../login'
-
-afterEach(() => cleanup())
-
-test('example 1', () => {
-  const handleSubmit = jest.fn()
-  const {getByLabelText} = render(<Login onSubmit={handleSubmit} />)
-  userEvent.type(getByLabelText(/username/i), 'kentcdodds')
-  userEvent.type(getByLabelText(/password/i), 'ilovetwix')
-  // more test here
-})
-
-test('example 2', () => {
-  const handleSubmit = jest.fn()
-  const {getByLabelText} = render(<Login onSubmit={handleSubmit} />)
-  userEvent.type(getByLabelText(/username/i), 'kentcdodds')
-  // more test here
-})
-```
-
-> Even better, with React Testing Library,
-> [`cleanup`](https://testing-library.com/docs/react-testing-library/api#cleanup)
-> is called after each test automatically by default. Learn more
-> [in the docs](https://testing-library.com/docs/react-testing-library/setup#skipping-auto-cleanup)
 
 In addition, sometimes there are definitely good use cases for `before*`, but
 they're normally matched with a cleanup that's necessary in an `after*`. Like

--- a/content/blog/avoid-nesting-when-youre-testing/index.mdx
+++ b/content/blog/avoid-nesting-when-youre-testing/index.mdx
@@ -97,29 +97,25 @@ Here's a test suite that resembles the kind of testing I've seen over the years.
 
 ```jsx
 // __tests__/login.js
-import {render} from '@testing-library/react'
+import {render, screen} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
 
 import Login from '../login'
 
 describe('Login', () => {
-  let utils,
-    handleSubmit,
-    user,
-    changeUsernameInput,
-    changePasswordInput,
-    clickSubmit
+  let handleSubmit, user, changeUsernameInput, changePasswordInput, clickSubmit
 
   beforeEach(() => {
     handleSubmit = jest.fn()
     user = {username: 'michelle', password: 'smith'}
-    utils = render(<Login onSubmit={handleSubmit} />)
+    render(<Login onSubmit={handleSubmit} />)
+
     changeUsernameInput = value =>
-      userEvent.type(utils.getByLabelText(/username/i), value)
+      userEvent.type(screen.getByLabelText(/username/i), value)
     changePasswordInput = value =>
-      userEvent.type(utils.getByLabelText(/password/i), value)
-    clickSubmit = () => userEvent.click(utils.getByText(/submit/i))
+      userEvent.type(screen.getByLabelText(/password/i), value)
+    clickSubmit = () => userEvent.click(screen.getByText(/submit/i))
   })
 
   describe('when username and password is provided', () => {
@@ -149,7 +145,7 @@ describe('Login', () => {
       let errorMessage
       beforeEach(() => {
         clickSubmit()
-        errorMessage = utils.getByRole('alert')
+        errorMessage = screen.getByRole('alert')
       })
 
       it('should show an error message', () => {
@@ -167,7 +163,7 @@ describe('Login', () => {
       let errorMessage
       beforeEach(() => {
         clickSubmit()
-        errorMessage = utils.getByRole('alert')
+        errorMessage = screen.getByRole('alert')
       })
 
       it('should show an error message', () => {
@@ -257,7 +253,7 @@ abstraction as possible. Check this out:
 
 ```jsx
 // __tests__/login.js
-import {render} from '@testing-library/react'
+import {render, screen} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
 
@@ -265,12 +261,12 @@ import Login from '../login'
 
 test('calls onSubmit with the username and password when submit is clicked', () => {
   const handleSubmit = jest.fn()
-  const {getByLabelText, getByText} = render(<Login onSubmit={handleSubmit} />)
   const user = {username: 'michelle', password: 'smith'}
+  render(<Login onSubmit={handleSubmit} />)
 
-  userEvent.type(getByLabelText(/username/i), user.username)
-  userEvent.type(getByLabelText(/password/i), user.password)
-  userEvent.click(getByText(/submit/i))
+  userEvent.type(screen.getByLabelText(/username/i), user.username)
+  userEvent.type(screen.getByLabelText(/password/i), user.password)
+  userEvent.click(screen.getByText(/submit/i))
 
   expect(handleSubmit).toHaveBeenCalledTimes(1)
   expect(handleSubmit).toHaveBeenCalledWith(user)
@@ -278,28 +274,24 @@ test('calls onSubmit with the username and password when submit is clicked', () 
 
 test('shows an error message when submit is clicked and no username is provided', () => {
   const handleSubmit = jest.fn()
-  const {getByLabelText, getByText, getByRole} = render(
-    <Login onSubmit={handleSubmit} />,
-  )
+  render(<Login onSubmit={handleSubmit} />)
 
-  userEvent.type(getByLabelText(/password/i), 'anything')
-  userEvent.click(getByText(/submit/i))
+  userEvent.type(screen.getByLabelText(/password/i), 'anything')
+  userEvent.click(screen.getByText(/submit/i))
 
-  const errorMessage = getByRole('alert')
+  const errorMessage = screen.getByRole('alert')
   expect(errorMessage).toHaveTextContent(/username is required/i)
   expect(handleSubmit).not.toHaveBeenCalled()
 })
 
 test('shows an error message when submit is clicked and no password is provided', () => {
   const handleSubmit = jest.fn()
-  const {getByLabelText, getByText, getByRole} = render(
-    <Login onSubmit={handleSubmit} />,
-  )
+  render(<Login onSubmit={handleSubmit} />)
 
-  userEvent.type(getByLabelText(/username/i), 'anything')
-  userEvent.click(getByText(/submit/i))
+  userEvent.type(screen.getByLabelText(/username/i), 'anything')
+  userEvent.click(screen.getByText(/submit/i))
 
-  const errorMessage = getByRole('alert')
+  const errorMessage = screen.getByRole('alert')
   expect(errorMessage).toHaveTextContent(/password is required/i)
   expect(handleSubmit).not.toHaveBeenCalled()
 })
@@ -335,7 +327,7 @@ assignments again and we'd like to avoid that. How else could we share code
 between our tests? AHA! We could use functions!
 
 ```jsx
-import {render} from '@testing-library/react'
+import {render, screen} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
 
@@ -347,15 +339,15 @@ import Login from '../login'
 // much abstraction. Read more: https://kcd.im/aha-testing
 function setup() {
   const handleSubmit = jest.fn()
-  const utils = render(<Login onSubmit={handleSubmit} />)
   const user = {username: 'michelle', password: 'smith'}
+  render(<Login onSubmit={handleSubmit} />)
+
   const changeUsernameInput = value =>
-    userEvent.type(utils.getByLabelText(/username/i), value)
+    userEvent.type(screen.getByLabelText(/username/i), value)
   const changePasswordInput = value =>
-    userEvent.type(utils.getByLabelText(/password/i), value)
-  const clickSubmit = () => userEvent.click(utils.getByText(/submit/i))
+    userEvent.type(screen.getByLabelText(/password/i), value)
+  const clickSubmit = () => userEvent.click(screen.getByText(/submit/i))
   return {
-    ...utils,
     handleSubmit,
     user,
     changeUsernameInput,
@@ -376,7 +368,7 @@ function setupWithNoPassword() {
   const utils = setup()
   utils.changeUsernameInput(utils.user.username)
   utils.clickSubmit()
-  const errorMessage = utils.getByRole('alert')
+  const errorMessage = screen.getByRole('alert')
   return {...utils, errorMessage}
 }
 
@@ -384,7 +376,7 @@ function setupWithNoUsername() {
   const utils = setup()
   utils.changePasswordInput(utils.user.password)
   utils.clickSubmit()
-  const errorMessage = utils.getByRole('alert')
+  const errorMessage = screen.getByRole('alert')
   return {...utils, errorMessage}
 }
 


### PR DESCRIPTION
Separated to 2 commits, since the section removal might be more controversial...

Single PR, because the `screen` update in that section would make it meaningless and not updating the section may end up even more confusing than the current disclaimer about automatic cleanup...