### PR TITLE
feat: create a json file containing posts on Kent blog

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -9,6 +9,7 @@ const remark = require('remark')
 const stripMarkdownPlugin = require('strip-markdown')
 const {zipFunctions} = require('@netlify/zip-it-and-ship-it')
 const config = require('./config/website')
+const blogUtils = require('./other/blog-utils')
 
 const twoDigits = n => (n.toString().length < 2 ? `0${n}` : n)
 
@@ -433,11 +434,12 @@ const onPreBootstrap = () => {
   }
 }
 
-const onPostBuild = async () => {
+const onPostBuild = async ({graphql}) => {
   if (process.env.gatsby_executing_command === 'develop') {
     return
   }
   require('./other/make-cache')
+  blogUtils.createJSONFile(graphql, './public/blog.json')
   const srcLocation = path.join(__dirname, `netlify/functions`)
   const outputLocation = path.join(__dirname, `public/functions`)
   if (fs.existsSync(outputLocation)) {

--- a/other/blog-utils.js
+++ b/other/blog-utils.js
@@ -1,0 +1,35 @@
+const fs = require('fs')
+
+async function createJSONFile(graphql, filePath) {
+  const queryResult = await graphql(`
+    {
+      blogposts: allMdx(
+        sort: {fields: frontmatter___date, order: DESC}
+        filter: {
+          frontmatter: {published: {ne: false}}
+          fileAbsolutePath: {regex: "//content/blog//"}
+        }
+      ) {
+        edges {
+          node {
+            fields {
+              id
+              slug
+              productionUrl
+              title
+              categories
+              keywords
+              description: plainTextDescription
+            }
+          }
+        }
+      }
+    }
+  `)
+
+  const posts = queryResult.data.blogposts.edges.map(edge => edge.node.fields)
+
+  fs.writeFileSync(`${filePath}`, JSON.stringify(posts))
+}
+
+module.exports = {createJSONFile}


### PR DESCRIPTION
Hi 👋

I was thinking to add a command on `kcd-bot` called `blog`.

The idea is to add few commands:

1. `?blog last` will show the list of the latest 10 articles 
2. `?blog react` will show the list of articles matching the word `react`

**Why this?**
A lot of time we post some articles on discord and we always should find on the site. 

**Why not making an API**
I thought that create a JSON file was a really fast way. Articles are not too much and the file is around 70 kb. 
The files will be created on build phase and put in the public folder. Of course in future an API could be created taking from different sources ( articles on blog or epic react etc.. ) 