### PR TITLE
fix: point derived state code sandbox to main branch

### DIFF
--- a/content/blog/dont-sync-state-derive-it/index.mdx
+++ b/content/blog/dont-sync-state-derive-it/index.mdx
@@ -23,7 +23,7 @@ In [my Learn React Hooks workshop](/workshops/react-hooks) material, we have an
 exercise where we build a tic-tac-toe game using React's `useState` hook (based
 on the official React tutorial). Here's the finished version of that exercise:
 
-https://codesandbox.io/s/github/kentcdodds/react-hooks/tree/6d0d635a90963cdd9e312fd3cd943bb74d20fcc4/?fontsize=14&hidenavigation=1&initialpath=/isolated/final/04.js&module=/src/final/04.js&theme=dark&file=/src/final/04.js
+https://codesandbox.io/s/github/kentcdodds/react-hooks/tree/main/?fontsize=14&hidenavigation=1&initialpath=/isolated/final/04.js&module=/src/final/04.js&theme=dark&file=/src/final/04.js
 
 We have a few variables of state. There's a `squares` state variable via
 `React.useState`. There's also `nextValue`, `winner`, and `status` are each


### PR DESCRIPTION
Hi Kent,

I changed the link to the first embedded codesandbox (tic tac toe) to point to the `main` branch of your react-hooks repo.

The currently linked branch `6d0d635a90963cdd9e312fd3cd943bb74d20fcc4` does not work in the codesandbox because it is missing the `repository` entry in `package.json`

I hope that helps.

Greetings,

Stefan 🚀🏆 (a.k.a. Hucki)