### PR TITLE
use render instead of renderIntoDocument

### DIFF
--- a/content/blog/test-isolation-with-react/index.mdx
+++ b/content/blog/test-isolation-with-react/index.mdx
@@ -273,7 +273,7 @@ import * as React from 'react'
 import {Counter} from '../counter'
 
 test('allows clicks until the maxClicks is reached, then requires a reset', () => {
-  const {getByText} = renderIntoDocument(
+  const {getByText} = render(
     <Counter maxClicks={4} initialCount={3} />,
   )
   const counterButton = getByText(/^count/i)


### PR DESCRIPTION
Probably intended to use `render` instead of  `renderIntoDocument`  in the fourth example.