### PR TITLE
Little mistake while putting args inside calls

### DIFF
--- a/content/blog/but-really-what-is-a-javascript-mock/index.mdx
+++ b/content/blog/but-really-what-is-a-javascript-mock/index.mdx
@@ -135,7 +135,7 @@ test('returns winner', () => {
   const originalGetWinner = utils.getWinner
   // eslint-disable-next-line import/namespace
   utils.getWinner = (...args) => {
-    utils.getWinner.mock.calls.push([...args])
+    utils.getWinner.mock.calls.push(args)
     return args[1]
   }
   utils.getWinner.mock = {calls: []}

--- a/content/blog/but-really-what-is-a-javascript-mock/index.mdx
+++ b/content/blog/but-really-what-is-a-javascript-mock/index.mdx
@@ -135,7 +135,7 @@ test('returns winner', () => {
   const originalGetWinner = utils.getWinner
   // eslint-disable-next-line import/namespace
   utils.getWinner = (...args) => {
-    utils.getWinner.mock.calls.push(...args)
+    utils.getWinner.mock.calls.push([...args])
     return args[1]
   }
   utils.getWinner.mock = {calls: []}


### PR DESCRIPTION
Maybe I got it wrong, but since `thumbWar` function calls `getWinner` function twice and you expect `utils.getWinner.mock.calls.length` to be 2, I think you actually want to put an array with all args each time, so you would have two arrays inside `calls`. 

```
expect(utils.getWinner.mock.calls).toHaveLength(2)
  utils.getWinner.mock.calls.forEach(args => {
    expect(args).toEqual(['Ken Wheeler', 'Kent C. Dodds'])
  })
```
These lines above made me believe you actually want to do `[ [ arg1, arg2 ], [ arg1, arg2 ] ]` instead of `[ arg1, arg2, arg1, arg2 ]`.

I hope I can be helpful. Thank you for the amazing job!