### PR TITLE
Broken link to nthCalledWith

### DIFF
--- a/content/blog/but-really-what-is-a-javascript-mock/index.mdx
+++ b/content/blog/but-really-what-is-a-javascript-mock/index.mdx
@@ -208,7 +208,7 @@ This effectively does all the same stuff we were doing, except because it's a
 special Jest mock function, there are some special assertions we can use just
 for that purpose (like `toHaveBeenCalledTimes`). Unfortunately there's not
 currently an assertion called `nthCalledWith`
-([though there will be one soon!](https://facebook.github.io/jest/docs/en/next/expect.html#nthcalledwithnthcall-arg1-arg2-)),
+([though there will be one soon!](https://jestjs.io/docs/en/next/expect.html#tohavebeennthcalledwithnthcall-arg1-arg2-)),
 otherwise we could have avoided our `forEach`, but I think it's ok as it is (and
 luckily we implemented our own metadata collection in the same way Jest does, so
 we don't need to change that assertion. Fancy that!).


### PR DESCRIPTION
Hi Kent 👋 , your Testing React Apps workshop took me all the way here.
It seems like the link to `nthCalledWith` is broken now and Jest has added this assertion function since this blog was written.
So, I thought I would fix the link in the short term and let you know that you might want to improve the example tests so that you can avoid using `forEach`.