### PR TITLE
Add two missing commas in how to contribute in open source article

### DIFF
--- a/content/blog/super-simple-start-to-netlify-functions/index.mdx
+++ b/content/blog/super-simple-start-to-netlify-functions/index.mdx
@@ -45,7 +45,7 @@ integration with GitHub is unmatched. I love it.
 Great, so now I've got static files served ultra-fast on the internet with
 Netlify's CDN. But how do I make it so my contact form can actually send emails?
 You may not be aware of this, but web browsers are not able to send emails
-themselves. To do that you need a server. I don't know about you, but managing
+themselves. To do that, you need a server. I don't know about you, but managing
 servers and databases are among the top things on the list of stuff I do NOT
 enjoy about web development.
 

--- a/content/blog/what-open-source-project-should-i-contribute-to/index.mdx
+++ b/content/blog/what-open-source-project-should-i-contribute-to/index.mdx
@@ -38,7 +38,7 @@ My silver bullet answer comes from my blog post
 
 Where I've found the most satisfaction out of contributing to open source is in
 projects that matter to me and (possibly) others. And then contributing to that
-project regularly. To do that you need to have an understanding of the use cases
+project regularly. To do that, you need to have an understanding of the use cases
 and pains associated with a particular tool or library. This is why I say _it's
 best to contribute to something you use regularly_.
 


### PR DESCRIPTION
## What:

Minor adjustment in the **how to contribute to open source** article on the [Kent C. Dodds](https://kentcdodds.com/blog/introducing-how-to-contribute-to-open-source) blog.

## Why:

Simple grammar correction.

## How:

Updated the following files:

- `super-simple-start-to-netlify-functions/index.mdx `
- `what-open-source-project-should-i-contribute-to/index.mdx`