### PR TITLE
Set cypress cache folder

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -12,3 +12,7 @@
 [build]
   command = "npm run netlify"
   functions = "public/functions/"
+
+[build.environment]
+  CYPRESS_CACHE_FOLDER = "./node_modules/CypressBinary"
+  TERM = "xterm"


### PR DESCRIPTION
Setting a cache folder for Cypress improves the build time since it does not have to be downloaded each time the build runs. 

It is also recommended by Cypress: https://github.com/cypress-io/netlify-plugin-cypress#recommended 👍 