### PR TITLE
Update wrapping-react-use-state-with-type-script

### DIFF
--- a/content/blog/wrapping-react-use-state-with-type-script/index.mdx
+++ b/content/blog/wrapping-react-use-state-with-type-script/index.mdx
@@ -68,38 +68,6 @@ function App() {
   )
 }
 
-function Home({
-  mode,
-  setMode,
-}: {
-  mode: DarkModeState
-  setMode: SetDarkModeState
-}) {
-  return (
-    <>
-      {/* ... */}
-      <Navigation mode={mode} setMode={setMode} />
-      {/* ... */}
-    </>
-  )
-}
-
-function Page({
-  mode,
-  setMode,
-}: {
-  mode: DarkModeState
-  setMode: SetDarkModeState
-}) {
-  return (
-    <>
-      {/* ... */}
-      <Navigation mode={mode} setMode={setMode} />
-      {/* ... */}
-    </>
-  )
-}
-
 function Navigation({
   mode,
   setMode,


### PR DESCRIPTION
Delete Home and Page components that are not needed for the core explanation.

(In this blog, `App` is using `<Navigation>` directly without intermediate components.)