### PR TITLE
Adding a suggestion about test coverage

### DIFF
--- a/content/blog/use-ternaries-rather-than-and-and-in-jsx/index.mdx
+++ b/content/blog/use-ternaries-rather-than-and-and-in-jsx/index.mdx
@@ -172,6 +172,8 @@ Personally, I think the ternary is more readable (if you disagree, remember that
 with familiarity than anything else). Whatever you do, you do you, just don't do
 bugs.
 
+Another benfit of using actual branching syntax is that test coverage tools can detect and indicate when your tests are not covering the one of the branches.
+
 ## Conclusion
 
 I'm well aware that we could've solved the contact problem by using


### PR DESCRIPTION
This is just a suggestion. I'm sure the same can be better written, and perhaps this is not necessarily the right place in the article for it.

I just found out this the other day.:

Our file had 100% coverage, yet there was no test for the case where the condition was false. This caused a bug in production.

I compared ternary operator with && and jest coverage report can detect when the tests are not running through `: null`.

Thank you Kent for all your content!