### PR TITLE
Update index.mdx

### DIFF
--- a/content/blog/typescript-function-syntaxes/index.mdx
+++ b/content/blog/typescript-function-syntaxes/index.mdx
@@ -544,7 +544,7 @@ type is still `Array<number | undefined>` (no narrowing applied).
 
 So we can write our own function and tell the compiler that it returns
 true/false for whether the given argument is a specific type. For us, we'll say
-that our function returns true if the given argument's type is included in one
+that our function returns true if the given argument's type is not included in one
 of the falsy value types.
 
 ```typescript


### PR DESCRIPTION
i'm not sure about the wording, but as far as I understand this, the value can't be something which is included in the FalsyType, as the FalsyTypes are excluded from the ValueType. So the value is everything but the FalsyTypes.

Additional thought: the typedBoolean function returns true or false not based on the types. The function itself is merely a help for a compiler to narrow down the value types which will be passed to the function. Thats why the whole sentence is a bit misleading.