### PR TITLE
keyof typeof operators => Operator

### DIFF
--- a/content/blog/how-to-write-a-react-component-in-typescript/index.mdx
+++ b/content/blog/how-to-write-a-react-component-in-typescript/index.mdx
@@ -296,7 +296,7 @@ const operations: Record<Operator, OperationFn> = {
 
 type CalculatorProps = {
   left: number
-  operator: keyof typeof operations
+  operator: Operator
   right: number
 }
 ```
@@ -331,7 +331,7 @@ const operations: Record<Operator, OperationFn> = {
 
 type CalculatorProps = {
   left: number
-  operator: keyof typeof operations
+  operator: Operator
   right: number
 }
 


### PR DESCRIPTION
I find it weird that you define an explicit Operator type but don't use it in props and use `keyof typeof operators` instead. 

Both works but one feels more natural than the other imho.
