### PR TITLE
Update link to next article that had been renamed

### DIFF
--- a/content/blog/how-to-write-a-react-component-in-typescript/index.mdx
+++ b/content/blog/how-to-write-a-react-component-in-typescript/index.mdx
@@ -295,4 +295,4 @@ the `operations` functions. Interestingly, this is a bit of a rabbit hole, but
 at the other end of it, the types are definitely better and you learn a few
 tricks along the way. Originally that was part of this blog post, but I decided
 to move it to its own post. Read all about it here:
-[How to write a type narrowing identity function (TNIF) in TypeScript](/blog/how-to-write-a-type-narrowing-identity-function-in-typescript).
+[How to write a Constrained Identity Function (CIF) in TypeScript](/blog/how-to-write-a-constrained-identity-function-in-typescript).


### PR DESCRIPTION
Looks like the link broke when the article being linked to was renamed. Hopefully this is the right one 😄 