### PR TITLE
Fix possible typo

### DIFF
--- a/content/blog/how-to-write-a-react-component-in-typescript/index.mdx
+++ b/content/blog/how-to-write-a-react-component-in-typescript/index.mdx
@@ -237,7 +237,7 @@ type CalculatorProps = {
 object, which is roughly equal to:
 
 ```tsx
-type OperationsObj = {
+type operations = {
   '+': (left: number, right: number) => number
   '-': (left: number, right: number) => number
   '*': (left: number, right: number) => number


### PR DESCRIPTION
On the first pass, I was confused to what `operationsObj` was referred to. I think it's unneeded to use that naming.