### PR TITLE
Updated a link

### DIFF
--- a/content/blog/state-colocation-will-make-your-react-app-faster/index.mdx
+++ b/content/blog/state-colocation-will-make-your-react-app-faster/index.mdx
@@ -281,7 +281,7 @@ app grows larger, especially if you're putting too much state into Redux.
 
 Fortunately, there are things you can do to help reduce the impact of these
 performance issues, like
-[using memoized Reselect selectors to optimize `mapState` functions](https://blog.isquaredsoftware.com/2018/11/react-redux-history-implementation/),
+[using memoized Reselect selectors to optimize `mapState` functions](https://blog.isquaredsoftware.com/2017/12/idiomatic-redux-using-reselect-selectors/),
 and the Redux docs have
 [additional info on improving performance of Redux apps](https://redux.js.org/faq).
 


### PR DESCRIPTION
The current link actually points to the history and implementation of react-redux as opposed to reselect-selectors