### PR TITLE
Fix typo in "One simple trick to optimize React re-renders" code sample

### DIFF
--- a/content/blog/optimize-react-re-renders/index.mdx
+++ b/content/blog/optimize-react-re-renders/index.mdx
@@ -48,7 +48,7 @@ function Logger(props) {
 
 function Counter() {
   const [count, setCount] = React.useState(0)
-  const increment = () => setCount(c => c + 1)
+  const increment = () => setCount(count => count + 1)
   return (
     <div>
       <button onClick={increment}>The count is {count}</button>


### PR DESCRIPTION
Fix typo in "[One simple trick to optimize React re-renders](https://kentcdodds.com/blog/optimize-react-re-renders)" code sample:
* Rename `c` to `count`.