### PR TITLE
Fix typo

### DIFF
--- a/content/blog/how-to-use-react-context-effectively/index.mdx
+++ b/content/blog/how-to-use-react-context-effectively/index.mdx
@@ -311,7 +311,7 @@ because we're doing it for them!
 
 ## What about dispatch `type` typos?
 
-At this point, you reduxers are yelling: "Hey, where are the action creators?!"
+At this point, your reducers are yelling: "Hey, where are the action creators?!"
 If you want to implement action creators that is fine by me, but I never liked
 action creators. I have always felt like they were an unnecessary abstraction.
 Also, if you are using TypeScript or Flow and have your actions well typed, then


### PR DESCRIPTION
fixed typo for "How to use React Context effectively"