### PR TITLE
Update link to test.each

### DIFF
--- a/content/blog/aha-testing/index.mdx
+++ b/content/blog/aha-testing/index.mdx
@@ -438,7 +438,7 @@ takes a little bit more work.
 
 I personally prefer [jest-in-case](https://github.com/atlassian/jest-in-case)
 but Jest has a built-in
-[`test.each`](https://jestjs.io/docs/en/api#testeachtable-name-fn-timeout)
+[`test.each`](https://jestjs.io/docs/api#testeachtablename-fn-timeout)
 functionality that you may find useful.
 
 ## Conclusion


### PR DESCRIPTION
It seems like the link to `test.each` no longer take to the correct location.